### PR TITLE
Changed: Use most frequent annotation_set_id from the high confidence Spans in the group, instead considering the correct Spans to be eligible to vote

### DIFF
--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -38,7 +38,7 @@ def grouped(group, target: str):
     verbose_validation_column_name = f"defined_to_be_correct_{target}"
     # all rows where is_correct is nan relate to an element which has no correct element partner
     eligible_to_vote = group['above_predicted_threshold'].fillna(False)
-    if not len(group.loc[eligible_to_vote][target]):  # group not eligible, but predicted grouping is correct
+    if not len(group.loc[eligible_to_vote][target]):  # fallback if none of the Spans provide confidence
         group[verbose_validation_column_name] = group[target].mode(dropna=False)[0]
     else:  # get the most frequent annotation_set_id from the high confidence Spans in this group
         group[verbose_validation_column_name] = group.loc[eligible_to_vote][target].mode(dropna=False)[0]

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -37,12 +37,11 @@ def grouped(group, target: str):
     """Define which of the correct element in the predicted group defines the "correct" group id_."""
     verbose_validation_column_name = f"defined_to_be_correct_{target}"
     # all rows where is_correct is nan relate to an element which has no correct element partner
-    correct = group["is_correct"].fillna(False)  # so fill nan with False as .loc will need boolean
-
-    if len(group.loc[correct][target]) == 0:  # no "correct" element in the group, but the predicted grouping is correct
+    eligible_to_vote = group['above_predicted_threshold'].fillna(False)
+    if not len(group.loc[eligible_to_vote][target]):  # group not eligible, but predicted grouping is correct
         group[verbose_validation_column_name] = group[target].mode(dropna=False)[0]
-    else:  # get the most frequent annotation_set_id from the *correct* Annotations in this group
-        group[verbose_validation_column_name] = group.loc[correct][target].mode(dropna=False)[0]
+    else:  # get the most frequent annotation_set_id from the high confidence Spans in this group
+        group[verbose_validation_column_name] = group.loc[eligible_to_vote][target].mode(dropna=False)[0]
 
     validation_column_name = f"is_correct_{target}"
     group[validation_column_name] = group[target] == group[verbose_validation_column_name]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1563,7 +1563,8 @@ class TestKonfuzioDataSetup(unittest.TestCase):
 
     def test_number_of_all_documents(self):
         """Count the number of all available documents online."""
-        assert len(self.prj._documents) == 44
+        project = Project(id_=None, project_folder=OFFLINE_PROJECT)
+        assert len(project._documents) == 44
 
     def test_create_empty_annotation(self):
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1563,8 +1563,7 @@ class TestKonfuzioDataSetup(unittest.TestCase):
 
     def test_number_of_all_documents(self):
         """Count the number of all available documents online."""
-        prj = Project(id_=TEST_PROJECT_ID)
-        assert len(prj._documents) == 44
+        assert len(self.prj._documents) == 44
 
     def test_create_empty_annotation(self):
         """

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -685,8 +685,52 @@ class TestEvaluation(unittest.TestCase):
         assert evaluation["false_negative"].sum() == 0
         assert evaluation["is_found_by_tokenizer"].sum() == 2
 
-    def test_grouped(self):
+    def test_grouped_both_above_threshold_both_correct(self):
         """Test if group catches all relevant errors."""
-        grouped(DataFrame([[True, 'a'], [False, 'b']], columns=['is_correct', 'target']), target='target')
-        grouped(DataFrame([[False, 'a'], [False, 'b']], columns=['is_correct', 'target']), target='target')
-        grouped(DataFrame([[None, 'a'], [None, 'b']], columns=['is_correct', 'target']), target='target')
+        result = grouped(
+            DataFrame(
+                [[True, 'a', True], [True, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
+            ),
+            target='target',
+        )
+        assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # todo: it could be a OR b
+
+    def test_grouped_both_above_threshold_one_correct(self):
+        """Test if group catches all relevant errors."""
+        result = grouped(
+            DataFrame(
+                [[True, 'a', True], [False, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
+            ),
+            target='target',
+        )
+        assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']
+
+    def test_grouped_one_above_threshold_none_correct(self):
+        """Test if group catches all relevant errors."""
+        result = grouped(
+            DataFrame(
+                [[False, 'a', False], [False, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
+            ),
+            target='target',
+        )
+        assert result['defined_to_be_correct_target'].to_list() == ['b', 'b']  # todo: it could be a OR b
+
+    def test_grouped_one_above_threshold_one_correct(self):
+        """Test if group catches all relevant errors."""
+        result = grouped(
+            DataFrame(
+                [[None, 'a', True], [None, 'b', False]], columns=['is_correct', 'target', 'above_predicted_threshold']
+            ),
+            target='target',
+        )
+        assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # todo: it could be a OR b
+
+    def test_grouped_none_above_threshold_none_correct(self):
+        """Test if group catches all relevant errors."""
+        result = grouped(
+            DataFrame(
+                [[None, 'a', False], [None, 'b', False]], columns=['is_correct', 'target', 'above_predicted_threshold']
+            ),
+            target='target',
+        )
+        assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # todo: it could be a OR b

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -713,7 +713,7 @@ class TestEvaluation(unittest.TestCase):
             ),
             target='target',
         )
-        assert result['defined_to_be_correct_target'].to_list() == ['b', 'b']  # todo: it could be a OR b
+        assert result['defined_to_be_correct_target'].to_list() == ['b', 'b']  # see reason in commit 4a66394
 
     def test_grouped_one_above_threshold_one_correct(self):
         """Test if group catches all relevant errors."""

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -686,7 +686,7 @@ class TestEvaluation(unittest.TestCase):
         assert evaluation["is_found_by_tokenizer"].sum() == 2
 
     def test_grouped_both_above_threshold_both_correct(self):
-        """Test grouped for two correct Spans over threshold."""
+        """Test grouped for two correct Spans where both are over threshold."""
         result = grouped(
             DataFrame(
                 [[True, 'a', True], [True, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
@@ -696,7 +696,7 @@ class TestEvaluation(unittest.TestCase):
         assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # todo: it could be a OR b
 
     def test_grouped_both_above_threshold_one_correct(self):
-        """Test grouped for two incorrect Spans over threshold."""
+        """Test grouped for one correct Span and one incorrect Span over threshold."""
         result = grouped(
             DataFrame(
                 [[True, 'a', True], [False, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
@@ -723,7 +723,7 @@ class TestEvaluation(unittest.TestCase):
             ),
             target='target',
         )
-        assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # todo: it could be a OR b
+        assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # it must be a, as a is above threshold
 
     def test_grouped_none_above_threshold_none_correct(self):
         """Test grouped for two Spans below threshold, while is_correct is empty."""

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -686,7 +686,7 @@ class TestEvaluation(unittest.TestCase):
         assert evaluation["is_found_by_tokenizer"].sum() == 2
 
     def test_grouped_both_above_threshold_both_correct(self):
-        """Test if group catches all relevant errors."""
+        """Test grouped for two correct Spans over threshold."""
         result = grouped(
             DataFrame(
                 [[True, 'a', True], [True, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
@@ -696,7 +696,7 @@ class TestEvaluation(unittest.TestCase):
         assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # todo: it could be a OR b
 
     def test_grouped_both_above_threshold_one_correct(self):
-        """Test if group catches all relevant errors."""
+        """Test grouped for two incorrect Spans over threshold."""
         result = grouped(
             DataFrame(
                 [[True, 'a', True], [False, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
@@ -705,8 +705,8 @@ class TestEvaluation(unittest.TestCase):
         )
         assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']
 
-    def test_grouped_one_above_threshold_none_correct(self):
-        """Test if group catches all relevant errors."""
+    def test_grouped_one_above_threshold_both_incorrect(self):
+        """Test grouped for incorrect Span over threshold and incorrect Span below threshold."""
         result = grouped(
             DataFrame(
                 [[False, 'a', False], [False, 'b', True]], columns=['is_correct', 'target', 'above_predicted_threshold']
@@ -715,8 +715,8 @@ class TestEvaluation(unittest.TestCase):
         )
         assert result['defined_to_be_correct_target'].to_list() == ['b', 'b']  # see reason in commit 4a66394
 
-    def test_grouped_one_above_threshold_one_correct(self):
-        """Test if group catches all relevant errors."""
+    def test_grouped_one_above_threshold_none_correct(self):
+        """Test grouped for Span below threshold and Span above threshold, while is_correct is empty."""
         result = grouped(
             DataFrame(
                 [[None, 'a', True], [None, 'b', False]], columns=['is_correct', 'target', 'above_predicted_threshold']
@@ -726,7 +726,7 @@ class TestEvaluation(unittest.TestCase):
         assert result['defined_to_be_correct_target'].to_list() == ['a', 'a']  # todo: it could be a OR b
 
     def test_grouped_none_above_threshold_none_correct(self):
-        """Test if group catches all relevant errors."""
+        """Test grouped for two Spans below threshold, while is_correct is empty."""
         result = grouped(
             DataFrame(
                 [[None, 'a', False], [None, 'b', False]], columns=['is_correct', 'target', 'above_predicted_threshold']


### PR DESCRIPTION
The "grouped" function in the evaluate.py in the SDK uses the mode to calculate the matching Annotation Set.
This does not work if the Tokenizer creates a large number of Spans that match correct Spans in the ground truth. Only because "correct" Spans are found, they should not be used for mode calculation as they have a confidence below label threshold.