### PR TITLE
Changed: Log File creation can be disabled via an environment variable

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -1667,7 +1667,7 @@ class Document(Data):
         self._n_pages = None
 
         # prepare local setup for document
-        if self.id_:
+        if self.is_online:
             pathlib.Path(self.document_folder).mkdir(parents=True, exist_ok=True)
         self.annotation_file_path = os.path.join(self.document_folder, "annotations.json5")
         self.annotation_set_file_path = os.path.join(self.document_folder, "annotation_sets.json5")

--- a/konfuzio_sdk/settings_importer.py
+++ b/konfuzio_sdk/settings_importer.py
@@ -27,7 +27,7 @@ LOG_FORMAT = (
 
 handlers = [logging.StreamHandler()]
 
-if config('LOG_TO_FILE', default=True):
+if config('LOG_TO_FILE', cast=bool, default=True):
     with open(LOG_FILE_PATH, "a") as f:
         if f.writable():
             handlers.append(logging.FileHandler(LOG_FILE_PATH))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,7 +110,7 @@ class TestKonfuzioSDKAPI(unittest.TestCase):
         """Test to get Document that does not exist."""
         with pytest.raises(HTTPError) as e:
             get_document_details(document_id=0, project_id=0)
-        assert 'You do not have permission' in str(e.value)
+        assert '404 Not Found' in str(e.value)
 
     def test_document_details_document_not_available_but_project_exists(self):
         """Test to get Document that does not exist."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2197,6 +2197,22 @@ class TestKonfuzioForceOfflineData(unittest.TestCase):
         assert len(al_spans) == 0
         assert al_tokenizer in label_span.regex_matching
 
+    def test_offline_project_creates_no_files(self):
+        """Test that an offline Project does not create any files, even if documents have IDs."""
+        virtual_project = Project(id_=None)
+        virtual_project.set_offline()
+        assert not os.path.isdir(virtual_project.project_folder)
+
+        virtual_category = Category(project=virtual_project)
+        virtual_document = Document(
+            project=virtual_project,
+            id_=999999999,
+            category=virtual_category,
+            dataset_status=2,
+            copy_of_id=999999999,
+        )
+        assert not os.path.isdir(virtual_document.document_folder)
+
 
 class TestFillOperation(unittest.TestCase):
     """Separate Test as we add non Labels to the Project."""


### PR DESCRIPTION
An environment variable (or an entry to the `.env` file) can now be used for disabling the creation of the log file.