### PR TITLE
Changed: Dependency for the `regex` package updated to use the latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setuptools.setup(
         'python-dateutil',
         'python-decouple',  # todo add ==3.3 ?
         'requests',  # todo add ==2.24.0 ?
-        'regex==2020.6.8',  # re module but better
+        'regex>=2020.6.8',  # re module but better
         'tabulate==0.8.7',  # Used to pretty print DataFrames
         'tqdm',
         'pathos==0.2.6',


### PR DESCRIPTION
This updates the [regex](https://pypi.org/project/regex/) package dependency from `regex==2020.6.8` to the latest version, for allowing the installation on machines that have no C++ compiler available.