### PR TITLE
Fixed: Two minor bugs that were wrongly filtering out Annotations when iterating through `AnnotationSet.annotations`

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -52,7 +52,7 @@ class Data:
             # Compare to virtual instances
             return self.id_local == other.id_local
         else:
-            return self.id_ and other and other.id_ and self.id_ == other.id_
+            return self.id_ is not None and other is not None and other.id_ is not None and self.id_ == other.id_
 
     def __hash__(self):
         """Make any online or local concept hashable. See https://stackoverflow.com/a/7152650."""

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -373,6 +373,8 @@ class AnnotationSet(Data):
             annotations = [ann for ann in self._annotations if ann.is_correct]
         elif ignore_below_threshold:
             annotations = [ann for ann in self._annotations if ann.is_correct or ann.confidence > ann.label.threshold]
+        else:
+            annotations = self._annotations
         return annotations
 
     @property

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1429,7 +1429,7 @@ class Trainer:
     def extraction_result_to_document(document: Document, extraction_result: dict) -> Document:
         """Return a virtual Document annotated with AI Model output."""
         virtual_doc = deepcopy(document)
-        virtual_annotation_set_id = 0  # counter for across mult. Annotation Set groups of a Label Set
+        virtual_annotation_set_id = 1  # counter for across mult. Annotation Set groups of a Label Set
 
         # define Annotation Set for the Category Label Set: todo: this is unclear from API side
         # default Annotation Set will be always added even if there are no predictions for it

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2236,6 +2236,17 @@ class TestKonfuzioForceOfflineData(unittest.TestCase):
         assert len(annotations) == 5  # 4 if top_annotations filter is used
         assert sorted([ann.id_ for ann in annotations]) == [16, 17, 18, 19, 24]  # [16, 18, 19, 24]
 
+    def test_annotationset_annotations(self):
+        """Test AnnotationSet.annotations method."""
+        project = LocalTextProject()
+        document = project.test_documents[-1]
+
+        annotation_set = document.annotation_sets()[0]
+
+        assert len(annotation_set.annotations()) == 1
+        assert len(annotation_set.annotations(use_correct=False)) == 10
+        assert len(annotation_set.annotations(use_correct=False, ignore_below_threshold=True)) == 9
+
     def test_label_spans_not_found_by_tokenizer(self):
         """Test Label spans_not_found_by_tokenizer method."""
         project = LocalTextProject()


### PR DESCRIPTION
This fixes two bugs:
1. Occurring during an edge case for `Data.__eq__` when the ID of an object is 0
2. The other when both the filters `use_correct` and `ignore_below_threshold` are False in `AnnotationSet.annotations`.

These were causing the Konfuzio Server to filter out all Annotations belonging to default LabelSets in the extraction results.

[Python SDK docs - AnnotationSet](https://dev.konfuzio.com/sdk/sourcecode.html#annotation-set)