### PR TITLE
Changed: GitHub actions use Ubuntu 22.04

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ on:
 # thanks to https://www.caktusgroup.com/blog/2021/02/11/automating-pypi-releases/
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
@@ -25,6 +25,7 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
     - name: Install dependencies
       run: |
+        apt-get -y install python3-pandas-lib
         python -m pip install --upgrade pip
         pip install --upgrade --upgrade-strategy eager -e .[dev]
     - name: Lint with flake8

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,7 +25,7 @@ jobs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
     - name: Install dependencies
       run: |
-        apt-get -y install python3-pandas-lib
+        sudo apt-get -y install python3-pandas-lib
         python -m pip install --upgrade pip
         pip install --upgrade --upgrade-strategy eager -e .[dev]
     - name: Lint with flake8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Following [GitHub's recommendation](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/), we switch our runners to use `ubuntu-latest`, which now corresponds to Ubuntu 22.04.