### PR TITLE
Fix: Small threshold bug

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -372,7 +372,7 @@ class AnnotationSet(Data):
         if use_correct:
             annotations = [ann for ann in self._annotations if ann.is_correct]
         elif ignore_below_threshold:
-            annotations = [ann for ann in self._annotations if ann.is_correct or ann.confidence > ann.label.threshold]
+            annotations = [ann for ann in self._annotations if ann.is_correct or ann.confidence >= ann.label.threshold]
         else:
             annotations = self._annotations
         return annotations


### PR DESCRIPTION
This fixes a minor bug which caused Annotations at the detection threshold to not be returned at the AnnotationSet level. 