### PR TITLE
Fixed: Bug in Automated Regex Generator that was producing duplicated capture group names

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -815,7 +815,11 @@ class Label(Data):
                             ]
                             before_regex += suggest_regex_for_string(to_rep_offset_string, replace_characters=True)
                         else:
-                            before_regex += before_span.annotation.label.base_regex(category)
+                            base_before_regex = before_span.annotation.label.base_regex(category)
+                            stripped_base_before_regex = re.sub(
+                                regex_to_remove_groupnames_full, r'\1', base_before_regex
+                            )
+                            before_regex += stripped_base_before_regex
                     before_reg_dict[spacer] = before_regex
 
                     after_regex = ''

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import pathlib
-import re
+import regex as re
 import shutil
 import time
 import zipfile

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -789,7 +789,8 @@ class Label(Data):
         label_regex_token = self.base_regex(category=category, annotations=all_annotations)
 
         search = [1, 3, 5]
-        regex_to_remove_groupnames = re.compile('<.*?>')
+        regex_to_remove_groupnames = re.compile(r'<.*?>')
+        regex_to_remove_groupnames_full = re.compile(r'\(\?:\(\?P<[^>]+>([^\)]+)\)\)')
 
         naive_proposal = label_regex_token
         regex_made = []
@@ -828,7 +829,10 @@ class Label(Data):
                             ]
                             after_regex += suggest_regex_for_string(to_rep_offset_string, replace_characters=True)
                         else:
-                            after_regex += after_span.annotation.label.base_regex(category)
+                            base_after_regex = after_span.annotation.label.base_regex(category)
+                            stripped_base_after_regex = re.sub(regex_to_remove_groupnames_full, r'\1', base_after_regex)
+                            after_regex += stripped_base_after_regex
+
                     after_reg_dict[spacer] = after_regex
 
                     spacer_proposals = [

--- a/konfuzio_sdk/utils.py
+++ b/konfuzio_sdk/utils.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 import operator
 import os
-import re
+import regex as re
 import unicodedata
 import zipfile
 from contextlib import contextmanager

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -13,7 +13,7 @@ from konfuzio_sdk.regex import (
 from konfuzio_sdk.utils import does_not_raise
 
 import logging
-import re
+import regex as re
 import unittest
 
 import pytest


### PR DESCRIPTION
Fixed a bug in the Regex Generator for each Label, where some capture group names were duplicated. This was also causing a ValidationError during integration with the Konfuzio Server.

See the documentation at:
- [Python API docs - Label.find_regex](https://dev.konfuzio.com/sdk/sourcecode.html#label)