### PR TITLE
Fix: "cannot pickle '_thread.RLock' object" error when saving with konfuzio_sdk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: pydocstyle
         exclude: ^README.md
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.9.0
     hooks:
     -   id: flake8

--- a/konfuzio_sdk/settings_importer.py
+++ b/konfuzio_sdk/settings_importer.py
@@ -25,12 +25,19 @@ LOG_FORMAT = (
     "[%(funcName)-20.20s][%(lineno)-4.4d] %(message)-10s"
 )
 
-handlers = [logging.StreamHandler()]
 
-if config('LOG_TO_FILE', cast=bool, default=True):
-    with open(LOG_FILE_PATH, "a") as f:
-        if f.writable():
-            handlers.append(logging.FileHandler(LOG_FILE_PATH))
+def get_handlers():
+    """Get logging handlers based on environment variables."""
+    handlers = [logging.StreamHandler()]
+
+    if config('LOG_TO_FILE', cast=bool, default=True):
+        with open(LOG_FILE_PATH, "a") as f:
+            if f.writable():
+                handlers.append(logging.FileHandler(LOG_FILE_PATH))
+
+    return handlers
 
 
-logging.basicConfig(level=config('LOGGING_LEVEL', default=logging.INFO, cast=int), format=LOG_FORMAT, handlers=handlers)
+logging.basicConfig(
+    level=config('LOGGING_LEVEL', default=logging.INFO, cast=int), format=LOG_FORMAT, handlers=get_handlers()
+)

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -18,6 +18,7 @@ import bz2
 import collections
 import difflib
 import functools
+import itertools
 import logging
 import os
 import pathlib
@@ -38,8 +39,7 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.utils.validation import check_is_fitted
 from tabulate import tabulate
 
-import konfuzio_sdk
-from konfuzio_sdk.data import Document, Annotation, Category, AnnotationSet, Label, LabelSet, Span
+from konfuzio_sdk.data import Data, Document, Annotation, Category, AnnotationSet, Label, LabelSet, Span
 from konfuzio_sdk.normalize import (
     normalize_to_float,
     normalize_to_date,
@@ -70,6 +70,9 @@ def load_model(pickle_path: str, max_ram: Union[None, str] = None):
     """
     if not os.path.isfile(pickle_path):
         raise FileNotFoundError("Invalid pickle file path:", pickle_path)
+
+    # The current local id iterator might otherwise be overriden
+    prev_local_id = next(Data.id_iter)
 
     try:
         with bz2.open(pickle_path, 'rb') as file:
@@ -102,6 +105,9 @@ def load_model(pickle_path: str, max_ram: Union[None, str] = None):
         logger.warning(f"Loading legacy {model.name} AI model.")
     else:
         logger.info(f"Loading {model.name} AI model.")
+
+    curr_local_id = next(Data.id_iter)
+    Data.id_iter = itertools.count(max(prev_local_id, curr_local_id))
 
     return model
 
@@ -1532,6 +1538,8 @@ class Trainer:
         logger.info('Getting save paths')
 
         if include_konfuzio:
+            import konfuzio_sdk
+
             cloudpickle.register_pickle_by_value(konfuzio_sdk)
             # todo register all dependencies?
 

--- a/tests/tokenizers/test_patterns.py
+++ b/tests/tokenizers/test_patterns.py
@@ -1944,7 +1944,6 @@ class TestAutomatedRegexTokenizer(TestTemplateRegexTokenizer):
 
         label.lose_weight()
 
-        label = self.category.labels[0]
         assert label._evaluations == {}
         assert label._tokens == {}
         assert label._regex == {}

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -243,7 +243,7 @@ class TestWhitespaceRFExtractionAI(unittest.TestCase):
         previous_size = asizeof.asizeof(self.pipeline)
 
         self.pipeline.pipeline_path = self.pipeline.save(
-            output_dir=self.project.model_folder, include_konfuzio=False, reduce_weight=True, max_ram="5MB"
+            output_dir=self.project.model_folder, include_konfuzio=True, reduce_weight=True, max_ram="5MB"
         )
         assert os.path.isfile(self.pipeline.pipeline_path)
 
@@ -413,7 +413,7 @@ class TestRegexRFExtractionAI(unittest.TestCase):
         previous_size = asizeof.asizeof(self.pipeline)
 
         self.pipeline.pipeline_path = self.pipeline.save(
-            output_dir=self.project.model_folder, include_konfuzio=False, reduce_weight=True, max_ram="5MB"
+            output_dir=self.project.model_folder, include_konfuzio=True, reduce_weight=True, max_ram="5MB"
         )
         assert os.path.isfile(self.pipeline.pipeline_path)
 


### PR DESCRIPTION
This fixes an error that arises when saving an RFExtractionAI model with the `include_konfuzio` option set to `True`. 

This also fixes a related issue where the local `Data` class `id_iter` counter would be reset to its value when saved potentially causing errors due to duplicated ids. 