### PR TITLE
Fix: Vertical merge sometimes not working for loaded RFExtractionAI models

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -2371,7 +2371,7 @@ class Document(Data):
         self._annotations = None
         self._annotation_sets = None
 
-    def merge_vertical(self, only_multiline_labels=True):
+    def merge_vertical(self, labels_has_multiline_annotation: Dict, only_multiline_labels=True):
         """
         Merge Annotations with the same Label.
 
@@ -2379,13 +2379,13 @@ class Document(Data):
         """
         logger.info("Vertical merging Annotations.")
         labels_dict = {}
-        for label in self.project.labels:
-            if not only_multiline_labels or label.has_multiline_annotations(categories=[self.category]):
-                labels_dict[label.id_local] = []
+        for label in self.category.labels:
+            if not only_multiline_labels or labels_has_multiline_annotation[label.name]:
+                labels_dict[label.name] = []
 
         for annotation in self.annotations(use_correct=False, ignore_below_threshold=True):
-            if annotation.label.id_local in labels_dict:
-                labels_dict[annotation.label.id_local].append(annotation)
+            if annotation.label.name in labels_dict:
+                labels_dict[annotation.label.name].append(annotation)
 
         for label_id in labels_dict:
             buffer = []

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1271,7 +1271,13 @@ class TestOfflineDataSetup(unittest.TestCase):
         assert len(document.spans()) == 4
         assert len(document.annotations(use_correct=False)) == 4
 
-        document.merge_vertical()
+        labels_has_multiline_annotation = {}
+        for label in document.category.labels:
+            labels_has_multiline_annotation[label.name] = label.has_multiline_annotations(
+                categories=[document.category]
+            )
+
+        document.merge_vertical(labels_has_multiline_annotation)
 
         label = document.annotations(use_correct=False)[0].label
         category = project.get_category_by_id(1)
@@ -1291,7 +1297,13 @@ class TestOfflineDataSetup(unittest.TestCase):
 
         assert label.has_multiline_annotations(categories=[category]) is True
 
-        document.merge_vertical()
+        labels_has_multiline_annotation = {}
+        for label in document.category.labels:
+            labels_has_multiline_annotation[label.name] = label.has_multiline_annotations(
+                categories=[document.category]
+            )
+
+        document.merge_vertical(labels_has_multiline_annotation)
 
         assert len(document.spans()) == 4
         assert len(document.annotations(use_correct=False)) == 2
@@ -1304,7 +1316,7 @@ class TestOfflineDataSetup(unittest.TestCase):
 
         assert len(document.annotations(use_correct=False)) == 6
 
-        document.merge_vertical(only_multiline_labels=False)
+        document.merge_vertical(labels_has_multiline_annotation={}, only_multiline_labels=False)
 
         assert len(document.annotations(use_correct=False)) == 4
         assert len(document.annotations(use_correct=False)[1].spans) == 3


### PR DESCRIPTION
This introduces a fix for the vertical merge logic caused by unhandled inconsistencies between the Category loaded from server and the Category saved with the RFExtractionAI model pickle file. 