### PR TITLE
Fixed: Runtime of Multimodal File Splitting Model testcases which was longer than necessary

### DIFF
--- a/tests/trainer/test_file_splitting.py
+++ b/tests/trainer/test_file_splitting.py
@@ -269,7 +269,7 @@ class TestMultimodalFileSplittingModel(unittest.TestCase):
         for page in pred[0].pages():
             if page.number == 1:
                 assert page.is_first_page
-                assert page.is_first_page_confidence == 1
+                assert page.is_first_page_confidence > 0.51
             else:
                 assert not page.is_first_page
                 assert page.is_first_page_confidence

--- a/tests/trainer/test_file_splitting.py
+++ b/tests/trainer/test_file_splitting.py
@@ -244,14 +244,12 @@ class TestMultimodalFileSplittingModel(unittest.TestCase):
         cls.project = Project(id_=46)
         cls.file_splitting_model = MultimodalFileSplittingModel(categories=cls.project.categories)
         if not TEST_WITH_FULL_DATASET:
-            cls.file_splitting_model.documents = [
-                document for category in cls.file_splitting_model.categories for document in category.documents()
-            ][:10]
+            cls.file_splitting_model.documents = [cls.file_splitting_model.categories[0].documents()[0]]
         cls.test_document = cls.file_splitting_model.test_documents[-1]
 
     def test_model_training(self):
         """Test model's fit() method."""
-        self.file_splitting_model.fit()
+        self.file_splitting_model.fit(epochs=2)
         assert self.file_splitting_model.model
 
     def test_run_page_prediction(self):

--- a/tests/trainer/test_file_splitting.py
+++ b/tests/trainer/test_file_splitting.py
@@ -290,7 +290,7 @@ class TestMultimodalFileSplittingModel(unittest.TestCase):
         if TEST_WITH_FULL_DATASET:
             assert splitting_ai.full_evaluation.tp() == 25
         else:
-            assert splitting_ai.full_evaluation.tp() == 10
+            assert splitting_ai.full_evaluation.tp() == 1
         assert splitting_ai.full_evaluation.fp() == 0
         assert splitting_ai.full_evaluation.fn() == 0
         assert splitting_ai.full_evaluation.tn() == 0


### PR DESCRIPTION
Multimodal File Splitting Model testcases are used to verify that the training pipeline is functional, which can be done with just a single training document and 2 epochs. Thus, the overall test suite now runs in about half the time.