### PR TITLE
Added: Option to initialize a Page without specifying offsets

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -100,10 +100,10 @@ class Page(Data):
         self,
         id_: Union[int, None],
         document: 'Document',
-        start_offset: int,
-        end_offset: int,
         number: int,
         original_size: Tuple[float, float],
+        start_offset: Optional[int] = None,
+        end_offset: Optional[int] = None,
     ):
         """Create a Page for a Document."""
         self.id_ = id_
@@ -113,6 +113,11 @@ class Page(Data):
         document.add_page(self)
         self.start_offset = start_offset
         self.end_offset = end_offset
+        if start_offset is None or end_offset is None:
+            page_texts = self.document.text.split('\f')
+            self.start_offset = sum([len(page_text) for page_text in page_texts[: self.index]]) + self.index
+            self.end_offset = self.start_offset + len(page_texts[self.index])
+
         self.image = None
         self._original_size = original_size
         self.width = self._original_size[0]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1244,6 +1244,21 @@ class TestOfflineDataSetup(unittest.TestCase):
         assert document.get_page_by_index(0).text == 'page1'
         assert document.get_page_by_index(1).text == 'page2'
 
+    def test_page_text_without_specifying_offsets(self):
+        """Test text Page when start and end offsets are implicitly calculated from the Document's text page breaks."""
+        document_bbox = {
+            '0': {'x0': 0, 'x1': 1, 'y0': 0, 'y1': 2, 'top': 10, 'bottom': 11, 'page_number': 1, 'text': 'p'}
+        }
+        document = Document(
+            project=self.project, category=self.category, text='page1\fpage2\fpage3', bbox=document_bbox
+        )
+        _ = Page(id_=1, number=1, original_size=(595.2, 841.68), document=document)
+        _ = Page(id_=2, number=2, original_size=(595.2, 841.68), document=document)
+        _ = Page(id_=3, number=3, original_size=(595.2, 841.68), document=document)
+        assert document.get_page_by_index(0).text == 'page1'
+        assert document.get_page_by_index(1).text == 'page2'
+        assert document.get_page_by_index(2).text == 'page3'
+
     def test_page_text_offsets(self):
         """Test text Page offsets."""
         document_bbox = {
@@ -1254,6 +1269,21 @@ class TestOfflineDataSetup(unittest.TestCase):
         page2 = Page(id_=2, number=2, original_size=(595.2, 841.68), document=document, start_offset=6, end_offset=11)
         assert page1.text == document.text[page1.start_offset : page1.end_offset]
         assert page2.text == document.text[page2.start_offset : page2.end_offset]
+
+    def test_page_text_offsets_without_specifying_offsets(self):
+        """Test Page offsets when implicitly calculated from the Document's text page breaks."""
+        document_bbox = {
+            '0': {'x0': 0, 'x1': 1, 'y0': 0, 'y1': 2, 'top': 10, 'bottom': 11, 'page_number': 1, 'text': 'p'}
+        }
+        document = Document(
+            project=self.project, category=self.category, text='page1\fpage2\fpage3', bbox=document_bbox
+        )
+        page1 = Page(id_=1, number=1, original_size=(595.2, 841.68), document=document)
+        page2 = Page(id_=2, number=2, original_size=(595.2, 841.68), document=document)
+        page3 = Page(id_=3, number=3, original_size=(595.2, 841.68), document=document)
+        assert page1.text == document.text[page1.start_offset : page1.end_offset]
+        assert page2.text == document.text[page2.start_offset : page2.end_offset]
+        assert page3.text == document.text[page3.start_offset : page3.end_offset]
 
     def test_page_get_bbox(self):
         """Test getting bbox for Page."""
@@ -1266,6 +1296,22 @@ class TestOfflineDataSetup(unittest.TestCase):
         document = Document(project=self.project, category=self.category, text='p1\fp2', bbox=document_bbox)
         page1 = Page(id_=1, number=1, original_size=(595.2, 841.68), document=document, start_offset=0, end_offset=2)
         page2 = Page(id_=2, number=2, original_size=(595.2, 841.68), document=document, start_offset=3, end_offset=5)
+        assert '0' in page1.get_bbox() and '2' in page1.get_bbox()
+        assert '8' in page2.get_bbox() and '10' in page2.get_bbox()
+        assert '0' not in page2.get_bbox() and '2' not in page2.get_bbox()
+        assert '8' not in page1.get_bbox() and '10' not in page1.get_bbox()
+
+    def test_page_get_bbox_without_specifying_offsets(self):
+        """Test getting bbox for Page when offsets are implicitly calculated from the Document's text page breaks."""
+        document_bbox = {
+            '0': {'x0': 0, 'x1': 1, 'y0': 0, 'y1': 2, 'top': 10, 'bottom': 11, 'page_number': 1, 'text': 'p'},
+            '2': {'x0': 1, 'x1': 0, 'y0': 0, 'y1': 2, 'top': 10, 'bottom': 11, 'page_number': 1, 'text': '1'},
+            '8': {'x0': 0, 'x1': 1, 'y0': 10, 'y1': 12, 'top': 10, 'bottom': 11, 'page_number': 2, 'text': 'p'},
+            '10': {'x0': 1, 'x1': 0, 'y0': 10, 'y1': 12, 'top': 10, 'bottom': 11, 'page_number': 2, 'text': '2'},
+        }
+        document = Document(project=self.project, category=self.category, text='p1\fp2', bbox=document_bbox)
+        page1 = Page(id_=1, number=1, original_size=(595.2, 841.68), document=document)
+        page2 = Page(id_=2, number=2, original_size=(595.2, 841.68), document=document)
         assert '0' in page1.get_bbox() and '2' in page1.get_bbox()
         assert '8' in page2.get_bbox() and '10' in page2.get_bbox()
         assert '0' not in page2.get_bbox() and '2' not in page2.get_bbox()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -630,7 +630,7 @@ class TestOfflineDataSetup(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         """Control the number of Documents created in the Test."""
-        assert len(cls.project.virtual_documents) == 59
+        assert len(cls.project.virtual_documents) == 62
 
     def test_document_only_needs_project(self):
         """Test that a Document can be created without Category."""


### PR DESCRIPTION
This adds an option to initialize a Page without specifying start and end offsets, which will fall back on the provided Document's text page breaks to calculate them.