### PR TITLE
Changed: feature_function retokenize setting takes on a smart default value

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -2339,10 +2339,13 @@ class Document(Data):
 
         return sorted(spans)
 
-    def eval_dict(self, use_correct=False) -> List[dict]:
+    def eval_dict(self, use_view_annotations=False, use_correct=False) -> List[dict]:
         """Use this dict to evaluate Documents. The speciality: For every Span of an Annotation create one entry."""
         result = []
-        annotations = self.annotations(use_correct=use_correct)
+        if use_view_annotations:
+            annotations = self.view_annotations()
+        else:
+            annotations = self.annotations(use_correct=use_correct)
         if not annotations:  # if there are no Annotations in this Documents
             result.append(Span(start_offset=0, end_offset=0).eval_dict())
         else:

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -84,7 +84,7 @@ def grouped(group, target: str):
     return group
 
 
-def compare(doc_a, doc_b, only_use_correct=False, use_view_annotations=True, strict=True) -> pandas.DataFrame:
+def compare(doc_a, doc_b, only_use_correct=False, use_view_annotations=False, strict=True) -> pandas.DataFrame:
     """Compare the Annotations of two potentially empty Documents wrt. to **all** Annotations.
 
     :param doc_a: Document which is assumed to be correct

--- a/konfuzio_sdk/tokenizer/base.py
+++ b/konfuzio_sdk/tokenizer/base.py
@@ -75,7 +75,7 @@ class AbstractTokenizer(metaclass=abc.ABCMeta):
 
         virtual_doc = deepcopy(document)
         self.tokenize(virtual_doc)
-        evaluation = compare(document, virtual_doc)
+        evaluation = compare(document, virtual_doc, use_view_annotations=False)
         logger.warning(
             f'{evaluation["tokenizer_true_positive"].sum()} of {evaluation["is_correct"].sum()} corrects'
             f' Spans are found by Tokenizer'

--- a/konfuzio_sdk/tokenizer/base.py
+++ b/konfuzio_sdk/tokenizer/base.py
@@ -96,7 +96,7 @@ class AbstractTokenizer(metaclass=abc.ABCMeta):
             virtual_doc = deepcopy(document)
             self.tokenize(virtual_doc)
             eval_list.append((document, virtual_doc))
-        return Evaluation(eval_list)
+        return Evaluation(eval_list, use_view_annotations=False)
 
     def missing_spans(self, document: Document) -> List[Span]:
         """

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -2205,7 +2205,7 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
         self,
         documents: List[Document],
         no_label_limit: Union[None, int, float] = None,
-        retokenize: Union[bool, None] = None,
+        retokenize: Optional[bool] = None,
         require_revised_annotations: bool = False,
     ) -> Tuple[List[pandas.DataFrame], list]:
         """Calculate features per Span of Annotations.

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -2374,7 +2374,9 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
 
         return self.clf
 
-    def evaluate_full(self, strict: bool = True, use_training_docs: bool = False) -> Evaluation:
+    def evaluate_full(
+        self, strict: bool = True, use_training_docs: bool = False, use_view_annotations: bool = True
+    ) -> Evaluation:
         """
         Evaluate the full pipeline on the pipeline's Test Documents.
 
@@ -2392,9 +2394,9 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
             predicted_doc = self.extract(document=document)
             eval_list.append((document, predicted_doc))
 
-        self.full_evaluation = Evaluation(eval_list, strict=strict)
+        full_evaluation = Evaluation(eval_list, strict=strict, use_view_annotations=use_view_annotations)
 
-        return self.full_evaluation
+        return full_evaluation
 
     def evaluate_tokenizer(self, use_training_docs: bool = False) -> Evaluation:
         """Evaluate the tokenizer."""
@@ -2437,7 +2439,7 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
             predicted_doc = self.extract_from_df(feats_df, virtual_doc)
             eval_list.append((document, predicted_doc))
 
-        clf_evaluation = Evaluation(eval_list)
+        clf_evaluation = Evaluation(eval_list, use_view_annotations=False)
 
         return clf_evaluation
 
@@ -2476,7 +2478,7 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
 
             eval_list.append((document, predicted_doc))
 
-        label_set_clf_evaluation = Evaluation(eval_list)
+        label_set_clf_evaluation = Evaluation(eval_list, use_view_annotations=False)
 
         return label_set_clf_evaluation
 

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -50,9 +50,18 @@ from konfuzio_sdk.normalize import (
     normalize_to_positive_float,
 )
 from konfuzio_sdk.regex import regex_matches
-from konfuzio_sdk.utils import get_timestamp, get_bbox, normalize_memory, get_sdk_version, memory_size_of
+from konfuzio_sdk.utils import (
+    get_timestamp,
+    get_bbox,
+    normalize_memory,
+    get_sdk_version,
+    memory_size_of,
+    sdk_isinstance,
+)
 
 from konfuzio_sdk.evaluate import Evaluation
+
+from konfuzio_sdk.tokenizer.base import ListTokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -2195,9 +2204,9 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
     def feature_function(
         self,
         documents: List[Document],
-        no_label_limit=None,
+        no_label_limit: Union[None, int, float] = None,
         retokenize: Union[bool, None] = None,
-        require_revised_annotations=False,
+        require_revised_annotations: bool = False,
     ) -> Tuple[List[pandas.DataFrame], list]:
         """Calculate features per Span of Annotations.
 
@@ -2212,7 +2221,7 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
         logger.info(f'{require_revised_annotations=}')
 
         if retokenize is None:
-            if self.tokenizer.__name__ == 'ListTokenizer':
+            if sdk_isinstance(self.tokenizer, ListTokenizer):
                 retokenize = False
             else:
                 retokenize = True

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -2196,7 +2196,7 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
         self,
         documents: List[Document],
         no_label_limit=None,
-        retokenize=True,
+        retokenize: Union[bool, None] = None,
         require_revised_annotations=False,
     ) -> Tuple[List[pandas.DataFrame], list]:
         """Calculate features per Span of Annotations.
@@ -2210,6 +2210,13 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
         logger.info(f'{no_label_limit=}')
         logger.info(f'{retokenize=}')
         logger.info(f'{require_revised_annotations=}')
+
+        if retokenize is None:
+            if self.tokenizer.__name__ == 'ListTokenizer':
+                retokenize = False
+            else:
+                retokenize = True
+            logger.info(f'retokenize option set to {retokenize} with tokenizer {self.tokenizer}')
 
         df_real_list = []
         df_raw_errors_list = []

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -452,7 +452,7 @@ class TestRegexRFExtractionAI(unittest.TestCase):
         assert 1e6 < memory_size_of(self.pipeline.category) < 2.2e6
 
         self.pipeline.df_train, self.pipeline.label_feature_list = self.pipeline.feature_function(
-            documents=self.pipeline.documents, retokenize=False, require_revised_annotations=False
+            documents=self.pipeline.documents, require_revised_annotations=False
         )
 
         assert 1e6 < memory_size_of(self.pipeline.category) < 2.2e6

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -311,18 +311,28 @@ class TestWhitespaceRFExtractionAI(unittest.TestCase):
 
     def test_06_evaluate_full(self):
         """Evaluate Whitespace RFExtractionAI Model."""
-        evaluation = self.pipeline.evaluate_full()
+        evaluation = self.pipeline.evaluate_full(use_view_annotations=False)
 
         assert evaluation.f1(None) == self.evaluate_full_result
 
         assert 5e5 < memory_size_of(evaluation.data) < 6e5
 
+        view_evaluation = self.pipeline.evaluate_full(use_view_annotations=True)
+        assert view_evaluation.f1(None) == self.evaluate_full_result == evaluation.f1(None)
+
+        assert 1e5 < memory_size_of(view_evaluation.data) < 2e5
+
     def test_07_data_quality(self):
         """Evaluate on training documents."""
-        evaluation = self.pipeline.evaluate_full(use_training_docs=True)
+        evaluation = self.pipeline.evaluate_full(use_training_docs=True, use_view_annotations=False)
         assert evaluation.f1(None) == self.data_quality_result
 
         assert 22e5 < memory_size_of(evaluation.data) < 24e5
+
+        view_evaluation = self.pipeline.evaluate_full(use_training_docs=True, use_view_annotations=True)
+        assert view_evaluation.f1(None) == self.data_quality_result == evaluation.f1(None)
+
+        assert 2e5 < memory_size_of(view_evaluation.data) < 4e5
 
     def test_08_tokenizer_quality(self):
         """Evaluate the tokenizer quality."""
@@ -534,17 +544,27 @@ class TestRegexRFExtractionAI(unittest.TestCase):
 
     def test_06_evaluate_full(self):
         """Evaluate DocumentEntityMultiClassModel."""
-        evaluation = self.pipeline.evaluate_full()
+        evaluation = self.pipeline.evaluate_full(use_view_annotations=False)
         assert evaluation.f1(None) == self.evaluate_full_result
 
         assert 1e5 < memory_size_of(evaluation.data) < 2e5
 
+        view_evaluation = self.pipeline.evaluate_full(use_view_annotations=True)
+        assert view_evaluation.f1(None) == self.evaluate_full_result == evaluation.f1(None)
+
+        assert 1e5 < memory_size_of(view_evaluation.data) < 2e5
+
     def test_07_data_quality(self):
         """Evaluate on training documents."""
-        evaluation = self.pipeline.evaluate_full(use_training_docs=True)
+        evaluation = self.pipeline.evaluate_full(use_training_docs=True, use_view_annotations=False)
         assert evaluation.f1(None) >= 0.94
 
         assert 4e5 < memory_size_of(evaluation.data) < 6e5
+
+        view_evaluation = self.pipeline.evaluate_full(use_training_docs=True, use_view_annotations=True)
+        assert view_evaluation.f1(None) >= 0.94
+
+        assert 2e5 < memory_size_of(view_evaluation.data) < 4e5
 
     def test_08_tokenizer_quality(self):
         """Evaluate the tokenizer quality."""


### PR DESCRIPTION
This change will automatically set the `retokenize` option of the `RFExtractionAI.feature_function` to its assumed optimal value, if no value is set by the SDK user. If we use the Whitespace Tokenizer, we set it to True so that we only create training Annotations which the AI would actually encounter in practice. If we use a trained ListTokenizer, we set it to False so that the AI is trained to discriminate between correct Annotations and overlapping false positives. 

This also includes a change to the evaluation function allowing it to handle overlapping Annotations and ignore Annotations which are above detection threshold, but overlapping with an Annotation with a higher confidence. 

