### PR TITLE
Changed: Categories compared by name

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -794,6 +794,10 @@ class Category(Data):
         """Return string representation of the Category."""
         return f"{self.name} ({self.id_})"
 
+    def __eq__(self, other: 'Category') -> bool:
+        """Compare two Categories."""
+        return self.name == other.name
+
 
 class CategoryAnnotation(Data):
     """Annotate the Category of a Page."""

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -796,7 +796,10 @@ class Category(Data):
 
     def __eq__(self, other: 'Category') -> bool:
         """Compare two Categories."""
-        return self.name == other.name
+        if other is not None:
+            return self.name == other.name
+        else:
+            return False
 
     def __hash__(self):
         """Make Category hashable."""

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -798,6 +798,10 @@ class Category(Data):
         """Compare two Categories."""
         return self.name == other.name
 
+    def __hash__(self):
+        """Make Category hashable."""
+        return hash(str(self.id_local))
+
 
 class CategoryAnnotation(Data):
     """Annotate the Category of a Page."""

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -665,6 +665,18 @@ class TestOfflineDataSetup(unittest.TestCase):
         for page in self.document.pages():
             assert page.category == self.category
 
+    def test_category_equality(self):
+        """Test Category equality."""
+        project = Project(id_=None)
+        category = Category(project=project, id_=1, name='category1')
+
+        category2 = Category(project=project, id_=1, name='category2')
+        assert category != category2
+        assert category not in [category2, None]
+
+        with pytest.raises(ValueError, match="is a duplicate and will not be added"):
+            _ = Category(project=project, id_=2, name='category1')
+
     def test_categorize_when_all_pages_have_same_category(self):
         """Test categorizing a Document when all Pages have the same Category."""
         document = Document(project=self.project, text="hello")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -619,8 +619,8 @@ class TestOfflineDataSetup(unittest.TestCase):
         """Initialize the test Project."""
         cls.project = Project(id_=None)
         cls.label = Label(project=cls.project, text='First Offline Label')
-        cls.category = Category(project=cls.project, id_=2)
-        cls.category2 = Category(project=cls.project, id_=3)
+        cls.category = Category(project=cls.project, id_=2, name='category1')
+        cls.category2 = Category(project=cls.project, id_=3, name='category2')
         cls.document = Document(project=cls.project, category=cls.category, text="Hello.")
         cls.label_set = LabelSet(project=cls.project, categories=[cls.category], id_=421)
         cls.label_set.add_label(cls.label)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -457,9 +457,9 @@ class TestCompare(unittest.TestCase):
     def test_strict_documents_with_different_category(self):
         """Test to not compare two Documents with different Categories."""
         project = Project(id_=None)
-        category = Category(project=project)
+        category = Category(project=project, name='category')
         document_a = Document(project=project, category=category)
-        another_category = Category(project=project)
+        another_category = Category(project=project, name='another_category')
         document_b = Document(project=project, category=another_category)
         with self.assertRaises(ValueError) as context:
             compare(document_a, document_b)

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -325,8 +325,8 @@ class TestTokensMultipleCategories(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Initialize the Project."""
         cls.project = Project(id_=None)
-        cls.category = Category(project=cls.project, id_=1)
-        cls.category_2 = Category(project=cls.project, id_=2)
+        cls.category = Category(project=cls.project, id_=1, name='Category1')
+        cls.category_2 = Category(project=cls.project, id_=2, name='Category2')
         cls.label_set = LabelSet(id_=2, project=cls.project, categories=[cls.category, cls.category_2])
         cls.label = Label(id_=3, text='LabelName', project=cls.project, label_sets=[cls.label_set])
 

--- a/tests/tokenizers/test_base.py
+++ b/tests/tokenizers/test_base.py
@@ -64,8 +64,8 @@ class TestAbstractTokenizer(unittest.TestCase):
         cls.tokenizer = DummyTokenizer()
 
         cls.project = Project(id_=None)
-        cls.category_1 = Category(project=cls.project, id_=1)
-        cls.category_2 = Category(project=cls.project, id_=2)
+        cls.category_1 = Category(project=cls.project, id_=1, name='Category1')
+        cls.category_2 = Category(project=cls.project, id_=2, name='Category2')
         label_set = LabelSet(id_=2, project=cls.project, categories=[cls.category_1, cls.category_2])
         label = Label(id_=3, text='LabelName', project=cls.project, label_sets=[label_set])
 

--- a/tests/tokenizers/test_patterns.py
+++ b/tests/tokenizers/test_patterns.py
@@ -31,8 +31,8 @@ class TestRegexTokenizer(unittest.TestCase):
     def setUpClass(cls) -> None:
         """Initialize the tokenizer and test setup."""
         cls.project = Project(id_=None)
-        cls.category = Category(project=cls.project, id_=1)
-        cls.category_2 = Category(project=cls.project, id_=2)
+        cls.category = Category(project=cls.project, id_=1, name='Category1')
+        cls.category_2 = Category(project=cls.project, id_=2, name='Category2')
         cls.label_set = LabelSet(id_=2, project=cls.project, categories=[cls.category, cls.category_2])
         cls.label = Label(id_=3, text='LabelName', project=cls.project, label_sets=[cls.label_set])
 


### PR DESCRIPTION
This changes the way Categories are compared. Instead of using the id_ or local_id, we now use Category.name so that Categories are still recognized as the same after being migrated and changing id. 