### PR TITLE
Changed: Extraction AI Document extraction Category change

### DIFF
--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1904,6 +1904,7 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
         inference_document = deepcopy(document)
 
         # In case document category was changed after RFExtractionAI training
+        inference_document._category = None
         inference_document.set_category(self.category)
 
         # 2. tokenize


### PR DESCRIPTION
This allows Documents to be extracted with an `RFExtractionAI` even if the Document does not belong to the same Category the AI was trained on.