### PR TITLE
Fix: Duplicate Annotation error when extracting Document

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -9,6 +9,8 @@ We use several concepts in the Konfuzio Platform. We are capitalize concepts in 
 - Bbox Validation Rules
 - Annotation
 - Annotation Set
+- Categorization AI
+- Categorization Model
 - Category
 - Category Annotation
 - Document

--- a/docs/sdk/sourcecode.rst
+++ b/docs/sdk/sourcecode.rst
@@ -275,7 +275,7 @@ AI Evaluation
 
 Extraction AI Evaluation
 ---------------------
-.. autoclass:: konfuzio_sdk.evaluate.Evaluation
+.. autoclass:: konfuzio_sdk.evaluate.ExtractionEvaluation
    :members:
    :noindex:
 

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -1282,7 +1282,9 @@ class Label(Data):
 class Span(Data):
     """A Span is a sequence of characters or whitespaces without line break."""
 
-    def __init__(self, start_offset: int, end_offset: int, annotation=None, strict_validation: bool = True):
+    def __init__(
+        self, start_offset: int, end_offset: int, annotation: 'Annotation' = None, strict_validation: bool = True
+    ):
         """
         Initialize the Span without bbox, to save storage.
 
@@ -2710,7 +2712,9 @@ class Document(Data):
         """
         if self._annotations is None:
             self.annotations()
-        if annotation not in self._annotations:
+
+        duplicated = [x for x in self._annotations if x == annotation]
+        if not duplicated:
             # Hotfix Text Annotation Server:
             #  Annotation belongs to a Label / Label Set that does not relate to the Category of the Document.
             # todo: add test that the Label and Label Set of an Annotation belong to the Category of the Document
@@ -2736,7 +2740,6 @@ class Document(Data):
                 else:
                     raise ValueError(f'We cannot add {annotation} to {self} where the Сategory is {self.category}')
         else:
-            duplicated = [x for x in self._annotations if x == annotation]
             exception_or_log_error(
                 msg=f'In {self} the {annotation} is a duplicate of {duplicated} and will not be added.',
                 fail_loudly=self.project._strict_data_validation,

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -2721,7 +2721,9 @@ class Document(Data):
             if self.category != self.project.no_category:
                 if annotation.label_set is not None:
                     if annotation.label_set.categories:
-                        if (self.category in annotation.label_set.categories) or (annotation.label.name == 'NO_LABEL'):
+                        if (self.category in annotation.label_set.categories) or (
+                            annotation.label is self.project.no_label
+                        ):
                             self._annotations.append(annotation)
                         else:
                             exception_or_log_error(
@@ -2735,7 +2737,7 @@ class Document(Data):
                 else:
                     raise ValueError(f'{annotation} has no Label Set, which cannot be added to {self}.')
             else:
-                if annotation.label.name == "NO_LABEL" and annotation.label_set.name_clean == "NO_LABEL_SET":
+                if annotation.label is self.project.no_label and annotation.label_set is self.project.no_label_set:
                     self._annotations.append(annotation)
                 else:
                     raise ValueError(f'We cannot add {annotation} to {self} where the Сategory is {self.category}')

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1240,19 +1240,22 @@ class Trainer(BaseModel):
 
             extracted_spans = extractions[required_fields].sort_values(by='confidence', ascending=False)
 
-            for span in extracted_spans.to_dict('records'):  # todo: are start_offset and end_offset always ints?
-                annotation = Annotation(
-                    document=document,
-                    label=label,
-                    confidence=span['confidence'],
-                    label_set=label_set,
-                    annotation_set=annotation_set,
-                    spans=[Span(start_offset=span['start_offset'], end_offset=span['end_offset'])],
-                )
-                if annotation.spans[0].offset_string is None:
-                    raise NotImplementedError(
-                        f"Extracted {annotation} does not have a correspondence in the " f"text of {document}."
+            for span in extracted_spans.to_dict('records'):
+                try:
+                    annotation = Annotation(
+                        document=document,
+                        label=label,
+                        confidence=span['confidence'],
+                        label_set=label_set,
+                        annotation_set=annotation_set,
+                        spans=[Span(start_offset=span['start_offset'], end_offset=span['end_offset'])],
                     )
+                    if annotation.spans[0].offset_string is None:
+                        raise NotImplementedError(
+                            f"Extracted {annotation} does not have a correspondence in the " f"text of {document}."
+                        )
+                except ValueError as e:
+                    logger.warning(f'Could not add {span}: {str(e)}')
 
     @classmethod
     def merge_horizontal(cls, res_dict: Dict, doc_text: str) -> Dict:

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1255,7 +1255,11 @@ class Trainer(BaseModel):
                             f"Extracted {annotation} does not have a correspondence in the " f"text of {document}."
                         )
                 except ValueError as e:
-                    logger.warning(f'Could not add {span}: {str(e)}')
+                    if 'is a duplicate of' in str(e):
+                        # Second duplicate Span is lower confidence since we sorted spans earlier, so we can ignore it
+                        logger.warning(f'Could not add duplicated {span}: {str(e)}')
+                    else:
+                        raise e
 
     @classmethod
     def merge_horizontal(cls, res_dict: Dict, doc_text: str) -> Dict:

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -1202,7 +1202,7 @@ class TestAddExtractionAsAnnotation(unittest.TestCase):
         assert document.annotations(use_correct=False) == []
 
     def test_add_same_offset_extractions_to_document(self):
-        """Test extractions  Document."""
+        """Test extractions Document."""
         document = deepcopy(self.sample_document)
         annotation_set_1 = AnnotationSet(id_=101, document=document, label_set=self.label_set)
 
@@ -1245,6 +1245,70 @@ class TestAddExtractionAsAnnotation(unittest.TestCase):
 
         assert len(document.annotations(use_correct=False)) == 1
         assert document.annotations(use_correct=False)[0].confidence == 0.4
+
+    def test_add_same_offset_different_labels_extractions_to_document(self):
+        """Test extractions same offset different Labels Document."""
+        document = deepcopy(self.sample_document)
+        label_set_1 = self.label_set
+        label_set_2 = self.project.get_label_set_by_id(1)
+
+        label_1 = self.label
+        label_2 = self.project.get_label_by_id(5)
+
+        annotation_set_1 = AnnotationSet(id_=103, document=document, label_set=label_set_1)
+        annotation_set_2 = AnnotationSet(id_=104, document=document, label_set=label_set_2)
+
+        extraction_df_label_1 = pd.DataFrame(
+            data=[
+                {
+                    'start_offset': 15,
+                    'end_offset': 20,
+                    'confidence': 0.1,
+                    'page_index': 0,
+                    'x0': 10,
+                    'x1': 20,
+                    'y0': 10,
+                    'y1': 20,
+                    'top': 200,
+                    'bottom': 210,
+                },
+            ]
+        )
+        extraction_df_label_2 = pd.DataFrame(
+            data=[
+                {
+                    'start_offset': 15,
+                    'end_offset': 20,
+                    'confidence': 0.4,
+                    'page_index': 0,
+                    'x0': 10,
+                    'x1': 20,
+                    'y0': 10,
+                    'y1': 20,
+                    'top': 200,
+                    'bottom': 210,
+                },
+            ]
+        )
+
+        RFExtractionAI().add_extractions_as_annotations(
+            extractions=extraction_df_label_1,
+            document=document,
+            label=label_1,
+            label_set=label_set_1,
+            annotation_set=annotation_set_1,
+        )
+
+        RFExtractionAI().add_extractions_as_annotations(
+            extractions=extraction_df_label_2,
+            document=document,
+            label=label_2,
+            label_set=label_set_2,
+            annotation_set=annotation_set_2,
+        )
+
+        assert len(document.annotations(use_correct=False)) == 2  # overlapping but different Labels
+        assert document.view_annotations()[0].label == label_2
 
     def test_add_empty_extraction_to_document(self):
         """Test add empty extraction to a document."""

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -34,7 +34,6 @@ from konfuzio_sdk.trainer.information_extraction import (
     strip_accents,
     count_string_differences,
     year_month_day_count,
-    # add_extractions_as_annotations,
     load_model,
     RFExtractionAI,
     Trainer,
@@ -1201,6 +1200,51 @@ class TestAddExtractionAsAnnotation(unittest.TestCase):
             annotation_set=annotation_set_1,
         )
         assert document.annotations(use_correct=False) == []
+
+    def test_add_same_offset_extractions_to_document(self):
+        """Test extractions  Document."""
+        document = deepcopy(self.sample_document)
+        annotation_set_1 = AnnotationSet(id_=101, document=document, label_set=self.label_set)
+
+        extraction_df = pd.DataFrame(
+            data=[
+                {
+                    'start_offset': 15,
+                    'end_offset': 20,
+                    'confidence': 0.1,
+                    'page_index': 0,
+                    'x0': 10,
+                    'x1': 20,
+                    'y0': 10,
+                    'y1': 20,
+                    'top': 200,
+                    'bottom': 210,
+                },
+                {
+                    'start_offset': 15,
+                    'end_offset': 20,
+                    'confidence': 0.4,
+                    'page_index': 0,
+                    'x0': 10,
+                    'x1': 20,
+                    'y0': 10,
+                    'y1': 20,
+                    'top': 200,
+                    'bottom': 210,
+                },
+            ]
+        )
+
+        RFExtractionAI().add_extractions_as_annotations(
+            extractions=extraction_df,
+            document=document,
+            label=self.label,
+            label_set=self.label_set,
+            annotation_set=annotation_set_1,
+        )
+
+        assert len(document.annotations(use_correct=False)) == 1
+        assert document.annotations(use_correct=False)[0].confidence == 0.4
 
     def test_add_empty_extraction_to_document(self):
         """Test add empty extraction to a document."""


### PR DESCRIPTION
This fixes an error that occurred when the horizontal merge logic would create a Span identical to one already created by the Tokenizer, thereby creating a duplicate Annotation error when adding it to the Document.