### PR TITLE
Changed: pandas version requirement updated to `pandas>=1.3.5,<2.0.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setuptools.setup(
         'filetype==1.0.7',  # Used to check that files are in the correct format
         'nltk',
         'numpy>=1.22.4',
-        'pandas>=1.3.5',
+        'pandas>=1.3.5,<2.0.0',
         'Pillow>=8.4.0',
         'python-dateutil',
         'python-decouple',  # todo add ==3.3 ?


### PR DESCRIPTION
This sets a maximum version to the pandas package to prevent the installation of pandas 2.x which is incompatible with the SDK. Compatibility with pandas 2.x will be added on April 28th.