### PR TITLE
Fixed: Default Evaluation filters out the case where a Label should only appear once per AnnotationSet

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -5,6 +5,8 @@ We use several concepts in the Konfuzio Platform. We are capitalize concepts in 
 
 - AI
 - AI Evaluation
+- Default Evaluation
+- Strict Evaluation
 - Bbox
 - Bbox Validation Rules
 - Annotation

--- a/docs/web/changelog_app.md
+++ b/docs/web/changelog_app.md
@@ -17,7 +17,6 @@ You can think of the _Planned_ section as a _Roadmap_ that lists Konfuzio Server
 
 - Add a filter to the list of Documents to find Documents that need to be revised by humans. ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/9242)).
 - Suggest page breaks if one file contains multiple Documents ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/7671)).
-- Perfomance improvement of the Konfuzio Server interface ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/10274)).
 - Delta Training, Partial Fit an exisiting classifier, so that training documents used previously can be deleted ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/9251)).
 - Allow administrators of Konfuzio on-premise installations to run a speedtest ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/9870)).
 - Start automatic AI retraining after User confirms that he has finished a annotation review ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/9166)).
@@ -30,7 +29,7 @@ Upcoming...
 
 This version uses the Konfuzio Python SDK in version v.0.2.15 and Konfuzio Document Validation UI in version v.0.1.4.
 
-Important note: This release changes the internal format of saved AIs. Therefore, you need to migrate existing AIs, before updating to this Konfuzio Server version. Please run "python manage.py resave_all_with_cloudpickle" to do so. This needs to be run after the usual [update actions](https://dev.konfuzio.com/web/on_premises.html#a-upgrade-to-newer-konfuzio-version). In case you need help or experience an issue with the migration please contact is via https://konfuzio.com/support. This Konfuzio Server will not start if umigrted AIs are present.
+Important note: This release changes the internal format of saved AIs. Therefore, you need to migrate existing AIs, before updating to this Konfuzio Server version. Please run "python manage.py resave_all_with_cloudpickle" to do so. This needs to be run after the usual [update actions](https://dev.konfuzio.com/web/on_premises.html#a-upgrade-to-newer-konfuzio-version). In case you need help or experience an issue with the migration please contact is via https://konfuzio.com/support. This Konfuzio Server will not start if unmigrated AIs are present.
 
 ### Added
 - Calculate and access Tokenizers via the web interface ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/9271)).

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -1833,6 +1833,7 @@ class Span(Data):
                 "revised": None,
                 "label_threshold": None,
                 "label_id": None,
+                "label_has_multiple_top_candidates": None,
                 "label_set_id": None,
                 "annotation_id": None,
                 "annotation_set_id": 0,  # to allow grouping to compare boolean
@@ -1859,6 +1860,9 @@ class Span(Data):
                 "data_type": None,
             }
         else:
+            label_has_multiple_top_candidates = None
+            if self.annotation is not None:
+                label_has_multiple_top_candidates = self.annotation.label.has_multiple_top_candidates
             span_dict = {
                 "id_local": self.annotation.id_local,
                 "id_": self.annotation.id_,
@@ -1874,6 +1878,7 @@ class Span(Data):
                 "revised": self.annotation.revised,
                 "label_threshold": self.annotation.label.threshold,  # todo: allow to optimize threshold
                 "label_id": self.annotation.label.id_,
+                "label_has_multiple_top_candidates": label_has_multiple_top_candidates,
                 "label_set_id": self.annotation.label_set.id_,
                 "annotation_id": self.annotation.id_,
                 "annotation_set_id": self.annotation.annotation_set.id_,

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -1860,9 +1860,6 @@ class Span(Data):
                 "data_type": None,
             }
         else:
-            label_has_multiple_top_candidates = None
-            if self.annotation is not None:
-                label_has_multiple_top_candidates = self.annotation.label.has_multiple_top_candidates
             span_dict = {
                 "id_local": self.annotation.id_local,
                 "id_": self.annotation.id_,
@@ -1878,7 +1875,7 @@ class Span(Data):
                 "revised": self.annotation.revised,
                 "label_threshold": self.annotation.label.threshold,  # todo: allow to optimize threshold
                 "label_id": self.annotation.label.id_,
-                "label_has_multiple_top_candidates": label_has_multiple_top_candidates,
+                "label_has_multiple_top_candidates": self.annotation.label.has_multiple_top_candidates,
                 "label_set_id": self.annotation.label_set.id_,
                 "annotation_id": self.annotation.id_,
                 "annotation_set_id": self.annotation.annotation_set.id_,

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -92,7 +92,11 @@ def compare(
     :param doc_a: Document which is assumed to be correct
     :param doc_b: Document which needs to be evaluated
     :param only_use_correct: Unrevised feedback in doc_a is assumed to be correct.
-    :param use_view_annotations: Use view_annotations filter to evaluate doc_b
+    :param use_view_annotations: Will filter for top confidence annotations. Only available when strict=True.
+     When use_view_annotations=True, it will compare only the highest confidence extractions to the ground truth
+     Annotations. When False (default), it compares all extractions to the ground truth Annotations. This setting is
+     ignored when strict=False, as the Default Evaluation (which uses strict=False) needs to compare all extractions.
+     For more details see https://help.konfuzio.com/modules/extractions/index.html#evaluation
     :param ignore_below_threshold: Ignore Annotations below detection threshold of the Label (only affects TNs)
     :param strict: Evaluate on a Character exact level without any postprocessing, an amount Span "5,55 " will not be
      exact with "5,55"
@@ -102,7 +106,7 @@ def compare(
     df_a = pandas.DataFrame(doc_a.eval_dict(use_correct=only_use_correct))
     df_b = pandas.DataFrame(
         doc_b.eval_dict(
-            use_view_annotations=strict and use_view_annotations,  # view_annotations only available for strict mode
+            use_view_annotations=strict and use_view_annotations,  # view_annotations only available for strict=True
             use_correct=False,
             ignore_below_threshold=ignore_below_threshold,
         )

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -233,12 +233,17 @@ def compare(
     )
 
     if not strict:
-        # After we have calculated the TPs, FPs, FNs for the Document, we filter out the case where a Label should only
-        # appear once per AnnotationSet but has been predicted multiple times. In this case, if any of the predictions
-        # is a TP then we keep one and discard FPs/FNs. If no TPs, if any of the predictions is a FP then we keep one
-        # and discard the FNs. If no FPs, then we keep a FN. The prediction we keep is always the first in terms of
-        # start_offset.
+
         def prioritize_rows(group):
+            """
+            Apply a filter when a Label should only appear once per AnnotationSet but has been predicted multiple times.
+
+            After we have calculated the TPs, FPs, FNs for the Document, we filter out the case where a Label should
+            only appear once per AnnotationSet but has been predicted multiple times. In this case, if any of the
+            predictions is a TP then we keep one and discard FPs/FNs. If no TPs, if any of the predictions is a FP
+            then we keep one and discard the FNs. If no FPs, then we keep a FN. The prediction we keep is always the
+            first in terms of start_offset.
+            """
             group = group[~group['label_has_multiple_top_candidates_predicted']]
             if group.empty:
                 return group

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -244,7 +244,7 @@ def compare(
             then we keep one and discard the FNs. If no FPs, then we keep a FN. The prediction we keep is always the
             first in terms of start_offset.
             """
-            group = group[~group['label_has_multiple_top_candidates_predicted']]
+            group = group[~(group['label_has_multiple_top_candidates_predicted'].astype(bool))]
             if group.empty:
                 return group
 
@@ -258,9 +258,7 @@ def compare(
             else:
                 return first_false_negative
 
-        spans = spans.groupby(['annotation_set_id_predicted', 'label_id_predicted'], group_keys=False).apply(
-            prioritize_rows
-        )
+        spans = spans.groupby(['annotation_set_id_predicted', 'label_id_predicted']).apply(prioritize_rows)
 
     spans = spans.replace({numpy.nan: None})
     # one Span must not be defined as TP or FP or FN more than once

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -101,7 +101,9 @@ def compare(
     df_a = pandas.DataFrame(doc_a.eval_dict(use_correct=only_use_correct))
     df_b = pandas.DataFrame(
         doc_b.eval_dict(
-            use_view_annotations=use_view_annotations, use_correct=False, ignore_below_threshold=ignore_below_threshold
+            use_view_annotations=strict and use_view_annotations,  # view_annotations only available for strict mode
+            use_correct=False,
+            ignore_below_threshold=ignore_below_threshold,
         )
     )
     if doc_a.category != doc_b.category:

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -2537,7 +2537,7 @@ class RFExtractionAI(Trainer, GroupAnnotationSets):
         """
         Evaluate the full pipeline on the pipeline's Test Documents.
 
-        :param strict: List of documents to extract features from.
+        :param strict: Evaluate on a Character exact level without any postprocessing.
         :param use_training_docs: Bool for whether to evaluate on the training documents instead of testing documents.
         :return: Evaluation object.
         """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -24,7 +24,6 @@ from konfuzio_sdk.data import (
     Bbox,
     BboxValidationTypes,
 )
-from konfuzio_sdk.evaluate import ExtractionEvaluation
 from konfuzio_sdk.trainer.information_extraction import RFExtractionAI
 from konfuzio_sdk.utils import is_file, get_spans_from_bbox
 from tests.variables import (
@@ -532,11 +531,7 @@ class TestOfflineExampleData(unittest.TestCase):
             documents=pipeline.documents, require_revised_annotations=False
         )
         pipeline.fit()
-        predictions = []
-        for doc in pipeline.documents:
-            predicted_doc = pipeline.extract(document=doc)
-            predictions.append(predicted_doc)
-        evaluation = ExtractionEvaluation(documents=list(zip(pipeline.documents, predictions)), strict=False)
+        evaluation = pipeline.evaluate_full(strict=False, use_training_docs=True)
         outliers = label.get_probable_outliers_by_confidence(evaluation, 0.8)
         assert len(outliers) == 1
         outlier_spans = [span.offset_string for annotation in outliers for span in annotation.spans]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -471,6 +471,8 @@ class TestCompare(unittest.TestCase):
         with "34", which counts as a TP. And because the Label associated to this Annotation has
         has_multiple_top_candidates=False, which means that as soon as 1 TP is found, FPs and FNs are discarded.
         Thus, the "67" extraction is not considered in the weak evaluation.
+
+        For more details see https://help.konfuzio.com/modules/extractions/index.html#evaluation
         """
         project = Project(id_=None)
         category = Category(project=project)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -11,6 +11,7 @@ from konfuzio_sdk.evaluate import compare, grouped, ExtractionEvaluation, Evalua
 
 from konfuzio_sdk.samples import LocalTextProject
 from konfuzio_sdk.tokenizer.regex import ConnectedTextTokenizer
+
 from konfuzio_sdk.trainer.file_splitting import ContextAwareFileSplittingModel, SplittingAI, FileSplittingEvaluation
 from tests.variables import TEST_DOCUMENT_ID
 
@@ -397,10 +398,10 @@ class TestCompare(unittest.TestCase):
         assert evaluation_strict["tokenizer_true_positive"].sum() == 0
 
         evaluation = compare(document_a, document_b, strict=False)
-        assert len(evaluation) == 3
+        assert len(evaluation) == 2
         assert evaluation["true_positive"].sum() == 1
         assert evaluation["false_positive"].sum() == 1
-        assert evaluation["false_negative"].sum() == 1
+        assert evaluation["false_negative"].sum() == 0
         assert evaluation["tokenizer_true_positive"].sum() == 0  # we don't find it with the tokenizer but only parts
 
     def test_non_strict_is_better_than_strict(self):
@@ -454,14 +455,8 @@ class TestCompare(unittest.TestCase):
         assert evaluation["false_negative"].sum() == 0
         assert evaluation["tokenizer_true_positive"].sum() == 0
 
-    @unittest.skip(reason='Feature needed')
     def test_non_strict_filters_out_fps_and_fns(self):
         """Test that weak evaluation should filter out the case where a Label should only appear once."""
-        # After we have calculated the results for the AnnotationSet, we filter out the case where a Label should only
-        # appear once per AnnotationSet but has been annotated multiple times. In this case, if any of the predictions
-        # is a TP then we keep one and discard FPs/FNs. If no TPs, if any of the predictions is a FP then we keep one
-        # and discard the FNs. If no FPs, then we keep a FN. The prediction we keep is always the first in terms of
-        # start_offset.
         project = Project(id_=None)
         category = Category(project=project)
         label_set = LabelSet(id_=33, project=project, categories=[category])

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -454,6 +454,73 @@ class TestCompare(unittest.TestCase):
         assert evaluation["false_negative"].sum() == 0
         assert evaluation["tokenizer_true_positive"].sum() == 0
 
+    @unittest.skip(reason='Feature needed')
+    def test_non_strict_filters_out_fps_and_fns(self):
+        """Test that weak evaluation should filter out the case where a Label should only appear once."""
+        # After we have calculated the results for the AnnotationSet, we filter out the case where a Label should only
+        # appear once per AnnotationSet but has been annotated multiple times. In this case, if any of the predictions
+        # is a TP then we keep one and discard FPs/FNs. If no TPs, if any of the predictions is a FP then we keep one
+        # and discard the FNs. If no FPs, then we keep a FN. The prediction we keep is always the first in terms of
+        # start_offset.
+        project = Project(id_=None)
+        category = Category(project=project)
+        label_set = LabelSet(id_=33, project=project, categories=[category])
+        label = Label(id_=22, project=project, label_sets=[label_set], threshold=0.1, has_multiple_top_candidates=False)
+        # create a Document A with text: "1234567890"; and annotations: "34"
+        document_a = Document(project=project, category=category, text="1234567890")
+        # Annotation Set
+        span_1 = Span(start_offset=2, end_offset=4)
+        annotation_set_a = AnnotationSet(id_=2, document=document_a, label_set=label_set)
+        _ = Annotation(
+            id_=2,
+            document=document_a,
+            is_correct=True,
+            annotation_set=annotation_set_a,
+            label=label,
+            label_set=label_set,
+            spans=[span_1],
+        )
+        # create a Document B with text: "1234567890"; and annotations "3" and "67"
+        document_b = Document(project=project, category=category, text="1234567890")
+        # Annotation Set
+        span_2 = Span(start_offset=2, end_offset=3)
+        span_3 = Span(start_offset=5, end_offset=7)
+        annotation_set_b = AnnotationSet(id_=3, document=document_b, label_set=label_set)
+        _ = Annotation(
+            id_=4,
+            document=document_b,
+            confidence=0.5,
+            is_correct=False,
+            annotation_set=annotation_set_b,
+            label=label,
+            label_set=label_set,
+            spans=[span_2],
+        )
+        _ = Annotation(
+            id_=5,
+            document=document_b,
+            confidence=0.5,
+            is_correct=False,
+            annotation_set=annotation_set_b,
+            label=label,
+            label_set=label_set,
+            spans=[span_3],
+        )
+
+        evaluation_strict = compare(document_a, document_b)
+        assert len(evaluation_strict) == 3
+        assert evaluation_strict["true_positive"].sum() == 0
+        assert evaluation_strict["false_positive"].sum() == 2
+        assert evaluation_strict["false_negative"].sum() == 1
+        assert evaluation_strict["tokenizer_true_positive"].sum() == 0
+
+        evaluation = compare(document_a, document_b, strict=False)
+        assert len(evaluation) == 1
+        assert evaluation["true_positive"].sum() == 1
+        assert evaluation["false_positive"].sum() == 0
+        assert evaluation["false_negative"].sum() == 0
+        assert evaluation["tokenizer_true_positive"].sum() == 0
+
     def test_strict_documents_with_different_category(self):
         """Test to not compare two Documents with different Categories."""
         project = Project(id_=None)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -456,12 +456,27 @@ class TestCompare(unittest.TestCase):
         assert evaluation["tokenizer_true_positive"].sum() == 0
 
     def test_non_strict_filters_out_fps_and_fns(self):
-        """Test that weak evaluation should filter out the case where a Label should only appear once."""
+        """
+        Test that weak evaluation should filter out the case where a Label should only appear once.
+
+        We will create two Documents to demonstrate non-strict evaluation.
+        Document A with text: "1234567890"; and Annotations: "34" (ground truth)
+        # Document B with text: "1234567890"; and Annotations "3" and "67" (predicted)
+
+        According to strict evaluation, there would be 2 FP and 1 FN,
+        because 2 Annotations were found that did not correspond to anything in the ground truth,
+        and because 1 Annotation in the ground truth was not matched in the predicted Document.
+
+        According to non-strict (weak) evaluation, there would be only 1 TP, because "3" is partially overlapping
+        with "34", which counts as a TP. And because the Label associated to this Annotation has
+        has_multiple_top_candidates=False, which means that as soon as 1 TP is found, FPs and FNs are discarded.
+        Thus, the "67" extraction is not considered in the weak evaluation.
+        """
         project = Project(id_=None)
         category = Category(project=project)
         label_set = LabelSet(id_=33, project=project, categories=[category])
         label = Label(id_=22, project=project, label_sets=[label_set], threshold=0.1, has_multiple_top_candidates=False)
-        # create a Document A with text: "1234567890"; and annotations: "34"
+        # create a Document A with text: "1234567890"; and Annotations: "34"
         document_a = Document(project=project, category=category, text="1234567890")
         # Annotation Set
         span_1 = Span(start_offset=2, end_offset=4)
@@ -475,7 +490,7 @@ class TestCompare(unittest.TestCase):
             label_set=label_set,
             spans=[span_1],
         )
-        # create a Document B with text: "1234567890"; and annotations "3" and "67"
+        # create a Document B with text: "1234567890"; and Annotations "3" and "67"
         document_b = Document(project=project, category=category, text="1234567890")
         # Annotation Set
         span_2 = Span(start_offset=2, end_offset=3)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -457,20 +457,20 @@ class TestCompare(unittest.TestCase):
 
     def test_non_strict_filters_out_fps_and_fns(self):
         """
-        Test that weak evaluation should filter out the case where a Label should only appear once.
+        Test that Default Evaluation should filter out the case where a Label should only appear once.
 
-        We will create two Documents to demonstrate non-strict evaluation.
+        We will create two Documents to demonstrate Default (non-Strict) Evaluation.
         Document A with text: "1234567890"; and Annotations: "34" (ground truth)
         # Document B with text: "1234567890"; and Annotations "3" and "67" (predicted)
 
-        According to strict evaluation, there would be 2 FP and 1 FN,
+        According to Strict Evaluation, there would be 2 FP and 1 FN,
         because 2 Annotations were found that did not correspond to anything in the ground truth,
         and because 1 Annotation in the ground truth was not matched in the predicted Document.
 
-        According to non-strict (weak) evaluation, there would be only 1 TP, because "3" is partially overlapping
+        According to Default (non-strict) Evaluation, there would be only 1 TP, because "3" is partially overlapping
         with "34", which counts as a TP. And because the Label associated to this Annotation has
         has_multiple_top_candidates=False, which means that as soon as 1 TP is found, FPs and FNs are discarded.
-        Thus, the "67" extraction is not considered in the weak evaluation.
+        Thus, the "67" extraction is not considered in the Default Evaluation.
 
         For more details see https://help.konfuzio.com/modules/extractions/index.html#evaluation
         """


### PR DESCRIPTION
When selecting Default Evaluation: After we have calculated the TPs, FPs, FNs for the Document, we filter out the case where a Label should only appear once per AnnotationSet but has been predicted multiple times. In this case, if any of the predictions is a TP then we keep one and discard FPs/FNs. If no TPs, if any of the predictions is a FP then we keep one and discard the FNs. If no FPs, then we keep a FN. The prediction we keep is always the first in terms of start_offset.

To see some examples of how it works in practice, see [Konfuzio Guide - Extraction AI Evaluation](https://help.konfuzio.com/modules/extractions/index.html#evaluation).