### PR TITLE
 Changed: Pages of sub-Documents after file splitting inherit Categories of Pages in the original Document

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -151,7 +151,7 @@ class Page(Data):
         )
         self.image_path = os.path.join(document_folder, f'page_{self.number}.png')
 
-        self._category = self.document._category
+        self._category = category if category else self.document._category
         self.category_annotations: List['CategoryAnnotation'] = []
         self._human_chosen_category_annotation: Optional[CategoryAnnotation] = None
         self.is_first_page = None
@@ -3599,6 +3599,7 @@ class Document(Data):
                         end_offset=end_offset,
                         copy_of_id=page_id,
                         number=i,
+                        category=page.category,
                     )
                     i += 1
                     start_offset = end_offset + 1
@@ -3612,6 +3613,7 @@ class Document(Data):
                         end_offset=end_offset,
                         copy_of_id=page_id,
                         number=i,
+                        category=page.category,
                     )
                     i += 1
                     start_offset = end_offset + 1

--- a/tests/trainer/test_file_splitting.py
+++ b/tests/trainer/test_file_splitting.py
@@ -171,6 +171,7 @@ class TestContextAwareFileSplittingModel(unittest.TestCase):
         pred = splitting_ai.propose_split_documents(test_document)
         assert len(pred) == 1
         assert len(pred[0].pages()) == 2
+        assert test_document.pages()[0].category == pred[0].pages()[0].category
 
     def test_splitting_ai_evaluate_full_on_training(self):
         """Test Splitting AI's evaluate_full on training Documents."""


### PR DESCRIPTION
Now Pages of sub-Documents after file splitting have the same Category as their counterparts in the original Document.