### PR TITLE
Changed: Use images instead of image_paths

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -3636,7 +3636,7 @@ class Document(Data):
 
     def get_document_classifier_examples(self, text_vocab, category_vocab, max_len, use_image, use_text):
         """Get the per document examples for the document classifier."""
-        document_image_paths = []
+        document_images = []
         document_tokens = []
         document_labels = []
         document_ids = []
@@ -3645,33 +3645,33 @@ class Document(Data):
         # validate the data for the document
         if use_image:
             self.get_images()  # gets the images if they do not exist
-            image_paths = [page.image_path for page in self.pages()]  # gets the paths to the images
+            images = [page.image for page in self.pages()]  # gets the paths to the images
             # @TODO move this validation to the Document class or the Page class
-            assert len(image_paths) > 0, f'No images found for document {self.id_}'
+            assert len(images) > 0, f'No images found for document {self.id_}'
             if not use_text:  # if only using images then make texts a list of None
-                page_texts = [None] * len(image_paths)
+                page_texts = [None] * len(images)
         if use_text:
             page_texts = self.text.split('\f')
             # @TODO move this validation to the Document class or the Page class
             assert len(page_texts) > 0, f'No text found for document {self.id_}'
             if not use_image:  # if only using text then make images used a list of None
-                image_paths = [None] * len(page_texts)
+                images = [None] * len(page_texts)
 
         # check we have the same number of images and text pages
         # only useful when we have both an image and a text module
         # @TODO move this validation to the Document class or the Page class
-        assert len(image_paths) == len(
+        assert len(images) == len(
             page_texts
-        ), f'No. of images ({len(image_paths)}) != No. of pages {len(page_texts)} for document {self.id_}'
+        ), f'No. of images ({len(images)}) != No. of pages {len(page_texts)} for document {self.id_}'
 
         for page in self.pages():
             if use_image:
                 # if using an image module, store the path to the image
-                document_image_paths.append(page.image_path)
+                document_images.append(page.image)
             else:
                 # if not using image module then don't need the image paths
                 # so we just have a list of None to keep the lists the same length
-                document_image_paths.append(None)
+                document_images.append(None)
             if use_text:
                 # if using a text module, tokenize the page, trim to max length and then numericalize
                 # REPLACE page_tokens = tokenizer.get_tokens(page_text)[:max_len]
@@ -3692,7 +3692,7 @@ class Document(Data):
             document_ids.append(torch.LongTensor([doc_id]))
             document_page_numbers.append(torch.LongTensor([page.index]))
 
-        return document_image_paths, document_tokens, document_labels, document_ids, document_page_numbers
+        return document_images, document_tokens, document_labels, document_ids, document_page_numbers
 
 
 class Project(Data):

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -3635,34 +3635,35 @@ class Document(Data):
         return new_doc
 
     def get_document_classifier_examples(self, text_vocab, category_vocab, max_len, use_image, use_text):
-        """Get the per document examples for the document classifier."""
+        """Get the per-Document examples for the Document classifier."""
         document_images = []
         document_tokens = []
         document_labels = []
         document_ids = []
         document_page_numbers = []
 
-        # validate the data for the document
+        # validate the data for the Document
         if use_image:
             self.get_images()  # gets the images if they do not exist
             images = [page.image for page in self.pages()]  # gets the paths to the images
             # @TODO move this validation to the Document class or the Page class
-            assert len(images) > 0, f'No images found for document {self.id_}'
+            assert len(images) > 0, f'No images found for Document {self.id_}'
             if not use_text:  # if only using images then make texts a list of None
                 page_texts = [None] * len(images)
         if use_text:
             page_texts = self.text.split('\f')
             # @TODO move this validation to the Document class or the Page class
-            assert len(page_texts) > 0, f'No text found for document {self.id_}'
+            assert len(page_texts) > 0, f'No text found for Document {self.id_}'
             if not use_image:  # if only using text then make images used a list of None
                 images = [None] * len(page_texts)
 
         # check we have the same number of images and text pages
         # only useful when we have both an image and a text module
         # @TODO move this validation to the Document class or the Page class
-        assert len(images) == len(
-            page_texts
-        ), f'No. of images ({len(images)}) != No. of pages {len(page_texts)} for document {self.id_}'
+        assert len(images) == len(page_texts), (
+            f'Number of images ({len(images)}) is not equal to the number of Pages {len(page_texts)} for Document '
+            f'{self.id_}'
+        )
 
         for page in self.pages():
             if use_image:
@@ -3673,7 +3674,7 @@ class Document(Data):
                 # so we just have a list of None to keep the lists the same length
                 document_images.append(None)
             if use_text:
-                # if using a text module, tokenize the page, trim to max length and then numericalize
+                # if using a text module, tokenize the Page, trim to max length and then numericalize
                 # REPLACE page_tokens = tokenizer.get_tokens(page_text)[:max_len]
                 # page_encoded = [text_vocab.stoi(span.offset_string) for span in
                 # self.spans(start_offset=page.start_offset, end_offset=page.end_offset)]
@@ -3684,9 +3685,9 @@ class Document(Data):
                 # if not using text module then don't need the tokens
                 # so we just have a list of None to keep the lists the same length
                 document_tokens.append(None)
-            # get document classification (defined by the category template)
+            # get Document classification (defined by the Category template)
             category_id = str(self.category.id_) if self.category != self.project.no_category else 'NO_CATEGORY'
-            # append the classification (category), the document's id number and the page number of each page
+            # append the classification (Category), the Document's ID and the number of each Page
             document_labels.append(torch.LongTensor([category_vocab.stoi(category_id)]))
             doc_id = self.id_ or self.copy_of_id
             document_ids.append(torch.LongTensor([doc_id]))

--- a/konfuzio_sdk/trainer/document_categorization.py
+++ b/konfuzio_sdk/trainer/document_categorization.py
@@ -13,7 +13,6 @@ from inspect import signature
 from typing import Union, List, Dict, Tuple, Optional
 from enum import Enum
 from warnings import warn
-from io import BytesIO
 
 import timm
 import torchvision
@@ -24,7 +23,6 @@ import transformers
 import numpy as np
 import pandas as pd
 import tqdm
-from PIL import Image
 from torch.utils.data import DataLoader
 
 from konfuzio_sdk.tokenizer.base import AbstractTokenizer
@@ -1275,7 +1273,6 @@ class CategorizationAI(AbstractCategorizationAI):
         for i, (img, txt) in enumerate(zip(page_images, page_text)):
             if use_image:
                 # if we are using images, open the image and perform preprocessing
-                img = Image.open(img)
                 img = self.eval_transforms(img)
                 batch_image.append(img)
             if use_text:
@@ -1352,10 +1349,8 @@ class CategorizationAI(AbstractCategorizationAI):
         docs_data_images = [None]
         use_image = hasattr(self.classifier, 'image_model')
         if use_image:
-            img_data = Image.open(page.image_path)
-            buf = BytesIO()
-            img_data.save(buf, format='PNG')
-            docs_data_images = [buf]
+            page.get_image()
+            docs_data_images = [page.image]
 
         use_text = hasattr(self.classifier, 'text_model')
         text_coded = [None]

--- a/konfuzio_sdk/trainer/document_categorization.py
+++ b/konfuzio_sdk/trainer/document_categorization.py
@@ -1065,10 +1065,9 @@ class CategorizationAI(AbstractCategorizationAI):
             data.extend(zip(*doc_info))
 
         def collate(batch, transforms) -> Dict[str, torch.LongTensor]:
-            image_path, text, label, doc_id, page_num = zip(*batch)
+            image, text, label, doc_id, page_num = zip(*batch)
             if use_image:
-                # if we are using images, open as PIL images, apply transforms and place on GPU
-                image = [Image.open(path) for path in image_path]
+                # if we are using images, they are already loaded as `PIL.Image`s, apply transforms and place on GPU
                 image = torch.stack([transforms(img) for img in image], dim=0).to(device)
                 image = image.to(device)
             else:

--- a/tests/trainer/test_document_categorization.py
+++ b/tests/trainer/test_document_categorization.py
@@ -563,3 +563,30 @@ def test_build_categorization_ai() -> None:
 
     pipeline_path = categorization_pipeline.save()
     load_model(pipeline_path)
+
+
+def test_get_document_classifier_examples():
+    """Test getting Document's classifier examples."""
+    from konfuzio_sdk.trainer.document_categorization import ImageModel, TextModel, build_categorization_ai_pipeline
+
+    project = Project(id_=None, project_folder=OFFLINE_PROJECT)
+    document = project.get_document_by_id(44823)
+    categorization_pipeline = build_categorization_ai_pipeline(
+        categories=[project.categories[0]],
+        documents=project.documents[:10],
+        test_documents=project.test_documents[:10],
+        image_model=ImageModel.EfficientNetB0,
+        text_model=TextModel.NBOWSelfAttention,
+    )
+    tokenized_doc = deepcopy(document)
+    tokenized_doc = WhitespaceTokenizer().tokenize(tokenized_doc)
+    tokenized_doc.status = document.status
+    doc_info = tokenized_doc.get_document_classifier_examples(
+        categorization_pipeline.text_vocab,
+        categorization_pipeline.category_vocab,
+        max_len=5000,
+        use_image=True,
+        use_text=True,
+    )
+    assert len(doc_info) == 5
+    assert doc_info[0][0].format == 'PNG'


### PR DESCRIPTION
Categorization was relying on `image_paths` to generate `Image` instances, but these are not always available. After https://github.com/konfuzio-ai/konfuzio-sdk/pull/270, however, we already have an `image` property on `Page` instances, which contains an `Image` instance that was built either from a file loaded from a path or from the bytes passed by the server, so this PR makes use of that property instead.