### PR TITLE
Changed: Additional data and `reduce_weight` in saved categorization pickle

### DIFF
--- a/docs/web/changelog_app.md
+++ b/docs/web/changelog_app.md
@@ -27,6 +27,14 @@ This version uses the Konfuzio Python SDK in version v.0.2.19 and Konfuzio Docum
 
 Upcoming...
 
+## released-2023-05-22_12-48-00
+
+This version uses the Konfuzio Python SDK in version v.0.2.18 and Konfuzio Document Validation UI in version v.0.1.6.
+
+### Fixed
+- Improved performance of the Annotations list webpage.  ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/11133)).
+- Improved performance of Document Search in the Smartview.  ([Internal Ticket](https://git.konfuzio.com/konfuzio/objectives/-/issues/11140)).
+
 ## released-2023-05-17_20-51-37
 
 This version uses the Konfuzio Python SDK in version v.0.2.18 and Konfuzio Document Validation UI in version v.0.1.6.

--- a/konfuzio_sdk/trainer/document_categorization.py
+++ b/konfuzio_sdk/trainer/document_categorization.py
@@ -919,7 +919,7 @@ class CategorizationAI(AbstractCategorizationAI):
 
         self.device = torch.device('cuda' if (torch.cuda.is_available() and use_cuda) else 'cpu')
 
-    def save(self, path: Union[None, str] = None) -> str:
+    def save(self, path: Union[None, str] = None, reduce_weight: bool = True) -> str:
         """
         Save only the necessary parts of the model for extraction/inference.
 
@@ -930,6 +930,9 @@ class CategorizationAI(AbstractCategorizationAI):
         - configs (to ensure we load the same models used in training)
         - state_dicts (the classifier parameters achieved through training)
         """
+        if reduce_weight:
+            self.reduce_model_weight()
+
         # create dictionary to save all necessary model data
         data_to_save = {
             'tokenizer': self.tokenizer,
@@ -938,6 +941,8 @@ class CategorizationAI(AbstractCategorizationAI):
             'text_vocab': self.text_vocab,
             'category_vocab': self.category_vocab,
             'classifier': self.classifier,
+            'eval_transforms': self.eval_transforms,
+            'train_transforms': self.train_transforms,
             'model_type': 'CategorizationAI',
         }
 
@@ -1218,6 +1223,10 @@ class CategorizationAI(AbstractCategorizationAI):
 
         return training_metrics
 
+    def reduce_model_weight(self):
+        """Reduce the size of the model by running lose_weight on the tokenizer."""
+        self.tokenizer.lose_weight()
+
     @torch.no_grad()
     def _predict(self, page_images, text, batch_size=2, *args, **kwargs) -> Tuple[Tuple[int, float], pd.DataFrame]:
         """
@@ -1496,7 +1505,14 @@ def build_categorization_ai_pipeline(
 
 COMMON_PARAMETERS = ['tokenizer', 'text_vocab', 'model_type']
 
-document_components = ['image_preprocessing', 'image_augmentation', 'category_vocab', 'classifier']
+document_components = [
+    'image_preprocessing',
+    'image_augmentation',
+    'category_vocab',
+    'classifier',
+    'eval_transforms',
+    'train_transforms',
+]
 
 document_components.extend(COMMON_PARAMETERS)
 
@@ -1534,6 +1550,8 @@ def _load_categorization_model(path: str):
     model.text_vocab = loaded_data['text_vocab']
     model.category_vocab = loaded_data['category_vocab']
     model.classifier = loaded_data['classifier']
+    model.eval_transforms = loaded_data['eval_transforms']
+    model.train_transforms = loaded_data['train_transforms']
     # need to ensure classifiers start in evaluation mode
     model.classifier.eval()
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setuptools.setup(
         'pympler>=1.0.1',  # Use to get pickle file size.
         'scikit-learn>=1.0.2',
         'timm==0.6.7',  # for extra pytorch models, i.e. EfficientNet
-        'spacy==3.1.4',  # used for spaCy tokenization
+        'spacy>=3.1.4',  # used for spaCy tokenization
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setuptools.setup(
         'pympler>=1.0.1',  # Use to get pickle file size.
         'scikit-learn>=1.0.2',
         'timm==0.6.7',  # for extra pytorch models, i.e. EfficientNet
-        'spacy>=3.1.4',  # used for spaCy tokenization
+        'spacy>=2.3.5, <=3.1.4',  # used for spaCy tokenization
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setuptools.setup(
         'pympler>=1.0.1',  # Use to get pickle file size.
         'scikit-learn>=1.0.2',
         'timm==0.6.7',  # for extra pytorch models, i.e. EfficientNet
-        'spacy>=2.3.5',  # used for spaCy tokenization
+        'spacy==2.3.5',  # used for spaCy tokenization
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setuptools.setup(
         'pympler>=1.0.1',  # Use to get pickle file size.
         'scikit-learn>=1.0.2',
         'timm==0.6.7',  # for extra pytorch models, i.e. EfficientNet
-        'spacy==2.3.5',  # used for spaCy tokenization
+        'spacy==3.1.4',  # used for spaCy tokenization
     ],
     extras_require={
         'dev': [

--- a/tests/trainer/test_document_categorization.py
+++ b/tests/trainer/test_document_categorization.py
@@ -489,6 +489,8 @@ class TestAllCategorizationConfigurations(unittest.TestCase):
 
     def test_3_save_model(self) -> None:
         """Test save .pt file to disk."""
+        reduced = self.categorization_pipeline.save(reduce_weight=True)
+        os.remove(reduced)
         self.categorization_pipeline.pipeline_path = self.categorization_pipeline.save()
         assert os.path.isfile(self.categorization_pipeline.pipeline_path)
 


### PR DESCRIPTION
* Reduce saved categorization pickle size by running `lose_weight` on the tokenizer
* Include `eval_transforms` and `train_transforms` in the saved pickle to ensure compatibility when loaded externally