### PR TITLE
Fix: ValueError Exception with non-strict Evaluation and Empty Extracted Document

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -1837,9 +1837,9 @@ class Span(Data):
                 "custom_offset_string": None,
                 "revised": None,
                 "label_threshold": None,
-                "label_id": None,
+                "label_id": 0,
                 "label_has_multiple_top_candidates": None,
-                "label_set_id": None,
+                "label_set_id": 0,
                 "annotation_id": None,
                 "annotation_set_id": 0,  # to allow grouping to compare boolean
                 "document_id": 0,

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1011,12 +1011,13 @@ class TestEvaluation(unittest.TestCase):
         assert evaluation.strict is False
 
     def test_not_strict_against_empty_document(self):
-        """Test that evaluation can be initialized with strict mode disabled."""
+        """Test that non-strict Evaluation can be used with Document with no extractions."""
         project = LocalTextProject()
         document = project.documents[0]
-        empty_extracted_document = deepcopy(document)
+        empty_extracted_document = deepcopy(document)  # no Annotation Document
         evaluation = ExtractionEvaluation(documents=[(document, empty_extracted_document)], strict=False)
         assert evaluation.strict is False
+        assert len(evaluation.data) == 0
 
     def test_true_positive(self):
         """Count two Spans from two Training Documents."""

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1010,6 +1010,14 @@ class TestEvaluation(unittest.TestCase):
         evaluation = ExtractionEvaluation(documents=list(zip(project.documents, project.documents)), strict=False)
         assert evaluation.strict is False
 
+    def test_not_strict_against_empty_document(self):
+        """Test that evaluation can be initialized with strict mode disabled."""
+        project = LocalTextProject()
+        document = project.documents[0]
+        empty_extracted_document = deepcopy(document)
+        evaluation = ExtractionEvaluation(documents=[(document, empty_extracted_document)], strict=False)
+        assert evaluation.strict is False
+
     def test_true_positive(self):
         """Count two Spans from two Training Documents."""
         project = LocalTextProject()

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1010,14 +1010,37 @@ class TestEvaluation(unittest.TestCase):
         evaluation = ExtractionEvaluation(documents=list(zip(project.documents, project.documents)), strict=False)
         assert evaluation.strict is False
 
-    def test_not_strict_against_empty_document(self):
-        """Test that non-strict Evaluation can be used with Document with no extractions."""
+    def test_not_strict_with_empty_evaluated_document(self):
+        """Test that non-strict Evaluation can be used with evaluated Document with no Annotations."""
         project = LocalTextProject()
         document = project.documents[0]
+        assert len(document.annotations(use_correct=True)) == 3
+        assert len(document.spans(use_correct=True)) == 3
         empty_extracted_document = deepcopy(document)  # no Annotation Document
+        assert len(empty_extracted_document.annotations(use_correct=False)) == 0
+        assert len(empty_extracted_document.spans(use_correct=False)) == 0
+        assert len(empty_extracted_document.eval_dict()) == 1
+        place_holder_span_eval_dict = empty_extracted_document.eval_dict()[0]
+        assert place_holder_span_eval_dict['start_offset'] == place_holder_span_eval_dict['end_offset'] == 0
         evaluation = ExtractionEvaluation(documents=[(document, empty_extracted_document)], strict=False)
         assert evaluation.strict is False
         assert len(evaluation.data) == 0
+
+    def test_not_strict_with_empty_reference_document(self):
+        """Test that non-strict Evaluation can be used with reference Document with no Annotations."""
+        project = LocalTextProject()
+        document = project.documents[0]
+        assert len(document.annotations(use_correct=True)) == 3
+        assert len(document.spans(use_correct=True)) == 3
+        empty_extracted_document = deepcopy(document)  # no Annotation Document
+        assert len(empty_extracted_document.annotations(use_correct=False)) == 0
+        assert len(empty_extracted_document.spans(use_correct=False)) == 0
+        assert len(empty_extracted_document.eval_dict()) == 1
+        place_holder_span_eval_dict = empty_extracted_document.eval_dict()[0]
+        assert place_holder_span_eval_dict['start_offset'] == place_holder_span_eval_dict['end_offset'] == 0
+        evaluation = ExtractionEvaluation(documents=[(empty_extracted_document, document)], strict=False)
+        assert evaluation.strict is False
+        assert len(evaluation.data) == 3
 
     def test_true_positive(self):
         """Count two Spans from two Training Documents."""


### PR DESCRIPTION
This fixes an error where the non-strict `ExtractionEvaluation` would throw a `ValueError` when it was used on a Document with no extractions. 