### PR TITLE
Fixed: spacy's version conflict with Python 3.10 & 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setuptools.setup(
         'transformers>=4.21.2',  # huggingface transformers and tokenizers
         'tqdm',
         'pympler>=1.0.1',  # Use to get pickle file size.
+        'pydantic==1.10.8',
         'scikit-learn>=1.0.2',
         'timm==0.6.7',  # for extra pytorch models, i.e. EfficientNet
         'spacy>=2.3.5, <=3.1.4',  # used for spaCy tokenization

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setuptools.setup(
         'transformers>=4.21.2',  # huggingface transformers and tokenizers
         'tqdm',
         'pympler>=1.0.1',  # Use to get pickle file size.
-        'pydantic==1.10.8',
+        'pydantic==1.10.8',  # pydantic is used by spacy. We need to force a higher pydantic version to avoid https://github.com/tiangolo/fastapi/issues/5048
         'scikit-learn>=1.0.2',
         'timm==0.6.7',  # for extra pytorch models, i.e. EfficientNet
         'spacy>=2.3.5, <=3.1.4',  # used for spaCy tokenization


### PR DESCRIPTION
Fixed an issue about spacy not running properly with the Python versions 3.10 and 3.11.