### PR TITLE
Fixed: Retain category annotations in subdocuments

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -3628,32 +3628,27 @@ class Document(Data):
         for page in self.pages():
             end_offset = start_offset + len(page.text)
             page_id = page.id_ if page.id_ else page.copy_of_id
-            if include:
-                if page.number in range(start_page.number, end_page.number + 1):
-                    _ = Page(
-                        id_=None,
-                        original_size=(page.height, page.width),
-                        document=new_doc,
-                        start_offset=start_offset,
-                        end_offset=end_offset,
-                        copy_of_id=page_id,
-                        number=i,
+            if (
+                (include and page.number in range(start_page.number, end_page.number + 1))
+                or (not include and page.number in range(start_page.number, end_page.number))
+            ):
+                new_page = Page(
+                    id_=None,
+                    original_size=(page.height, page.width),
+                    document=new_doc,
+                    start_offset=start_offset,
+                    end_offset=end_offset,
+                    copy_of_id=page_id,
+                    number=i,
+                )
+                for category_annotation in page.category_annotations:
+                    CategoryAnnotation(
+                        category=category_annotation.category,
+                        confidence=category_annotation.confidence,
+                        page=new_page,
                     )
-                    i += 1
-                    start_offset = end_offset + 1
-            else:
-                if page.number in range(start_page.number, end_page.number):
-                    _ = Page(
-                        id_=None,
-                        original_size=(page.height, page.width),
-                        document=new_doc,
-                        start_offset=start_offset,
-                        end_offset=end_offset,
-                        copy_of_id=page_id,
-                        number=i,
-                    )
-                    i += 1
-                    start_offset = end_offset + 1
+                i += 1
+                start_offset = end_offset + 1
         return new_doc
 
     def get_document_classifier_examples(self, text_vocab, category_vocab, max_len, use_image, use_text):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1959,10 +1959,16 @@ class TestOfflineDataSetup(unittest.TestCase):
         """Test creating a smaller Document from original one within a Page range."""
         project = LocalTextProject()
         test_document = project.get_document_by_id(9)
+        # Set page categories so we can check if they are copied correctly
+        for page in test_document.pages():
+            page.set_category(test_document.category)
         new_doc = test_document.create_subdocument_from_page_range(
             test_document.pages()[0], test_document.pages()[1], include=True
         )
         assert len(new_doc.pages()) == 2
+        for page in new_doc.pages():
+            assert page.category == test_document.category
+            assert len(page.category_annotations) == 1
         assert new_doc.text == "Hi all,\nI like bread.\n\fI hope to get everything done soon.\n"
 
     def test_page_is_first_attribute(self):


### PR DESCRIPTION
When using `create_subdocument_from_page_range`, i.e. during splitting, the resulting Document's Pages did not retain the category annotations from the original Pages.