### PR TITLE
Removed: Top level WIP warnings in information extraction and document categorization files

### DIFF
--- a/konfuzio_sdk/trainer/document_categorization.py
+++ b/konfuzio_sdk/trainer/document_categorization.py
@@ -12,7 +12,6 @@ from copy import deepcopy
 from inspect import signature
 from typing import Union, List, Dict, Tuple, Optional
 from enum import Enum
-from warnings import warn
 
 import timm
 import torchvision
@@ -34,8 +33,6 @@ from konfuzio_sdk.trainer.image import ImagePreProcessing, ImageDataAugmentation
 from konfuzio_sdk.utils import get_timestamp
 
 logger = logging.getLogger(__name__)
-
-warn('This module is WIP: https://gitlab.com/konfuzio/objectives/-/issues/9481', FutureWarning, stacklevel=2)
 
 
 class AbstractCategorizationAI(metaclass=abc.ABCMeta):

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -32,7 +32,6 @@ from copy import deepcopy
 from heapq import nsmallest
 from inspect import signature
 from typing import Tuple, Optional, List, Union, Dict
-from warnings import warn
 
 import cloudpickle
 import lz4.frame
@@ -69,8 +68,6 @@ logger = logging.getLogger(__name__)
 
 """Multiclass classifier for document extraction."""
 CANDIDATES_CACHE_SIZE = 100
-
-warn('This module is WIP: https://gitlab.com/konfuzio/objectives/-/issues/9311', FutureWarning, stacklevel=2)
 
 
 def load_model(pickle_path: str, max_ram: Union[None, str] = None):


### PR DESCRIPTION
This removes obsolete WIP warnings in the training module. 