### PR TITLE
Fix: Downgrade scikit-learn dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setuptools.setup(
         'pympler>=1.0.1',  # Use to get pickle file size.
         'pydantic==1.10.8',  # pydantic is used by spacy. We need to force a higher pydantic version to avoid
         # https://github.com/tiangolo/fastapi/issues/5048
-        'scikit-learn>=1.0.2',
+        'scikit-learn==1.2.2',
         'timm==0.6.7',  # for extra pytorch models, i.e. EfficientNet
         'spacy>=2.3.5',  # used for spaCy tokenization
     ],


### PR DESCRIPTION
Latest scikit-learn 1.3.0 release is introducing some breaking changes to older pickled extraction AIs. This fixes the scikit-learn version to 1.2.2.