### PR TITLE
Fix: Bug preventing saving of custom Extraction AI with no Tokenizer

### DIFF
--- a/konfuzio_sdk/trainer/base.py
+++ b/konfuzio_sdk/trainer/base.py
@@ -25,6 +25,7 @@ class BaseModel(metaclass=abc.ABCMeta):
     def __init__(self):
         """Initialize a BaseModel class."""
         self.output_dir = None
+        self.tokenizer = None
         self.documents = None
         self.test_documents = None
         self.python_version = '.'.join([str(v) for v in sys.version_info[:3]])
@@ -134,7 +135,12 @@ class BaseModel(metaclass=abc.ABCMeta):
     def reduce_model_weight(self):
         """Remove all non-strictly necessary parameters before saving."""
         self.project.lose_weight()
-        self.tokenizer.lose_weight()
+        if (
+            self.tokenizer is not None
+            and hasattr(self.tokenizer, "lose_weight")
+            and callable(self.tokenizer.lose_weight)
+        ):
+            self.tokenizer.lose_weight()
 
     def ensure_model_memory_usage_within_limit(self, max_ram: Optional[str] = None):
         """

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -1385,7 +1385,7 @@ class TestCustomExtractionAI(unittest.TestCase):
         cls.sample_document = cls.project.local_none_document
         cls.pipeline = ToyCustomExtractionAI(category=cls.category)
 
-    def test_toy_custom_extraction_ai(self):
+    def test_01_toy_custom_extraction_ai(self):
         """Test creation of a toy Custom ExtractionAI."""
         assert self.pipeline.category is self.category
         empty_doc = self.pipeline.extract(self.sample_document)
@@ -1393,11 +1393,11 @@ class TestCustomExtractionAI(unittest.TestCase):
 
         self.pipeline.pipeline_path = self.pipeline.save()
 
-    def test_load_model(self):
+    def test_02_load_model(self):
         """Test loading and running the saved model."""
         is_file(self.pipeline.pipeline_path, raise_exception=True)
-        loaded_pipeline = ToyCustomExtractionAI.load(self.pipeline.pipeline_path)
-        assert loaded_pipeline.category is self.category
+        loaded_pipeline = ToyCustomExtractionAI.load_model(self.pipeline.pipeline_path)
+        assert loaded_pipeline.category == self.category
         empty_doc = loaded_pipeline.extract(self.sample_document)
         assert len(empty_doc.annotations(use_correct=False)) == 0
 

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -706,7 +706,6 @@ class TestRegexRFExtractionAI(unittest.TestCase):
 
         for f in os.listdir(dir):
             os.remove(os.path.join(dir, f))
-
         if os.path.isfile(cls.pipeline.pipeline_path):
             os.remove(cls.pipeline.pipeline_path)  # cleanup
             os.remove(cls.pipeline.pipeline_path_no_konfuzio_sdk)
@@ -1384,18 +1383,30 @@ class TestCustomExtractionAI(unittest.TestCase):
         cls.project = LocalTextProject()
         cls.category = cls.project.get_category_by_id(1)
         cls.sample_document = cls.project.local_none_document
+        cls.pipeline = ToyCustomExtractionAI(category=cls.category)
 
     def test_toy_custom_extraction_ai(self):
         """Test creation of a toy Custom ExtractionAI."""
-        pipeline = ToyCustomExtractionAI(category=self.category)
-        assert pipeline.category is self.category
-        empty_doc = pipeline.extract(self.sample_document)
+        assert self.pipeline.category is self.category
+        empty_doc = self.pipeline.extract(self.sample_document)
         assert len(empty_doc.annotations(use_correct=False)) == 0
 
-        model_path = pipeline.save()
-        is_file(model_path, raise_exception=True)
+        self.pipeline.pipeline_path = self.pipeline.save()
 
-        os.remove(model_path)
+    def test_load_model(self):
+        """Test loading and running the saved model."""
+        is_file(self.pipeline.pipeline_path, raise_exception=True)
+        loaded_pipeline = ToyCustomExtractionAI.load(self.pipeline.pipeline_path)
+        assert loaded_pipeline.category is self.category
+        empty_doc = loaded_pipeline.extract(self.sample_document)
+        assert len(empty_doc.annotations(use_correct=False)) == 0
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clear created files."""
+        is_file(cls.pipeline.pipeline_path, raise_exception=True)
+
+        os.remove(cls.pipeline.pipeline_path)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This fixes a bug where Custom Extraction AIs without Tokenizer were prevented from being saved. 