### PR TITLE
Changed: Abstract ExtractionAI extract method 

### DIFF
--- a/docs/sdk/boilerplates/test_paragraph_extraction_ai.py
+++ b/docs/sdk/boilerplates/test_paragraph_extraction_ai.py
@@ -3,8 +3,6 @@ import logging
 import os
 
 # start imports
-from copy import deepcopy
-
 from konfuzio_sdk.trainer.information_extraction import AbstractExtractionAI
 from konfuzio_sdk.tokenizer.paragraph_and_sentence import ParagraphTokenizer
 from konfuzio_sdk.data import Category, Document, Project, Label
@@ -47,11 +45,7 @@ class ParagraphExtractionAI(AbstractExtractionAI):
         :raises:
         AttributeError: When missing a Tokenizer
         """
-        logger.info(f"Starting extraction of {document}.")
-
-        self.check_is_ready()
-
-        inference_document = deepcopy(document)
+        inference_document = super().extract(document)
 
         inference_document = self.tokenizer.tokenize(inference_document)
 

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -858,6 +858,8 @@ class AbstractExtractionAI(BaseModel):
 
     def extract(self, document: Document) -> Document:
         """Perform preliminary extraction steps."""
+        logger.info(f"Starting extraction of {document}.")
+
         self.check_is_ready()  # check if the model is ready for extraction
 
         document = deepcopy(document)  # to get a Virtual Document with no Annotations

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -856,10 +856,17 @@ class AbstractExtractionAI(BaseModel):
         logger.warning(f'{self} does not evaluate results.')
         pass
 
-    def extract(self):
-        """Use as placeholder Function."""
-        logger.warning(f'{self} does not extract.')
-        pass
+    def extract(self, document: Document) -> Document:
+        """Perform preliminary extraction steps."""
+        self.check_is_ready()  # check if the model is ready for extraction
+
+        document = deepcopy(document)  # to get a Virtual Document with no Annotations
+
+        # So that the Document belongs to the Category that is saved with the ExtractionAI
+        document._category = self.project.no_category
+        document.set_category(self.category)
+
+        return document
 
     def extraction_result_to_document(self, document: Document, extraction_result: dict) -> Document:
         """Return a virtual Document annotated with AI Model output."""
@@ -1653,17 +1660,8 @@ class RFExtractionAI(AbstractExtractionAI, GroupAnnotationSets):
          NotFittedError: When CLF is not fitted
 
         """
-        logger.info(f"Starting extraction of {document}.")
-
-        self.check_is_ready()
-
-        # Main Logic -------------------------
-        # 1. start inference with new document
-        inference_document = deepcopy(document)
-
-        # In case document category was changed after RFExtractionAI training
-        inference_document._category = self.project.no_category
-        inference_document.set_category(self.category)
+        # 1. create Virtual inference Document with Category set to the Category of the ExtractionAI
+        inference_document = super().extract(document)
 
         # 2. tokenize
         self.tokenizer.tokenize(inference_document)

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -1370,7 +1370,7 @@ class ToyCustomExtractionAI(AbstractExtractionAI):
 
     def extract(self, document: Document) -> Document:
         """Extract toy extraction AI."""
-        empty_doc = deepcopy(document)
+        empty_doc = super().extract(document)
         return empty_doc
 
 


### PR DESCRIPTION
Required preliminary steps required at the beginning of an ExtractionAI's extract method are now performed within the `AbstractExtractionAI.extract` method and all ExtractionAIs inheriting from it are expected to pass 

`AbstractExtractionAI.extract` now:
- Checks if the ExtractionAI is ready (`self.check_is_ready()`), 
- Creates a Virtual Document with no Annotations (`document = deepcopy(document)`)
- Changes the Category of the Virtual Document to the Category saved with the ExtractionAI (important if the Category was changed since saving, or in case the ExtractionAI was transferred to a new Category with a different id_)
- Returns the Virtual Document so that the Child class can add Annotations to it. 