### PR TITLE
Removed WIP warning in Span.bbox

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -1814,8 +1814,6 @@ class Span(Data):
         _ = self.line_index  # quick validate if start and end is in the same line of text
 
         if self._bbox is None:
-            warn('WIP: Modifications before the next stable release expected.', FutureWarning, stacklevel=2)
-            # todo: verify that one Span relates to Character in on line of text
             character_range = range(self.start_offset, self.end_offset)
             document = self.document
             characters = {key: document.bboxes.get(key) for key in character_range if document.text[key] != ' '}

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -3371,7 +3371,6 @@ class Document(Data):
     @property
     def bboxes(self) -> Dict[int, Bbox]:
         """Use the cached bbox version."""
-        warn('WIP: Modifications before the next stable release expected.', FutureWarning, stacklevel=2)
         if self.bboxes_available and self._characters is None:
             bbox = self.get_bbox()
             boxes = {}


### PR DESCRIPTION
This removes a WIP warning in the `Span.bbox` method. 