### PR TITLE
Changed: warning log for zero width/height Bbox

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -527,12 +527,7 @@ class Bbox:
         round_decimals = 2
 
         if round(self.x0, round_decimals) == round(self.x1, round_decimals):
-            exception_or_log_error(
-                msg=f"{self} has no width in {self.page}.",
-                fail_loudly=validation is BboxValidationTypes.STRICT,
-                exception_type=ValueError,
-                handler=handler,
-            )
+            logger.warning(f"{self} has no width in {self.page}.")
 
         if round(self.x0, round_decimals) > round(self.x1, round_decimals):
             exception_or_log_error(
@@ -543,12 +538,7 @@ class Bbox:
             )
 
         if round(self.y0, round_decimals) == round(self.y1, round_decimals):
-            exception_or_log_error(
-                msg=f"{self} has no height in {self.page}.",
-                fail_loudly=validation is BboxValidationTypes.STRICT,
-                exception_type=ValueError,
-                handler=handler,
-            )
+            logger.warning(f"{self} has no height in {self.page}.")
 
         if round(self.y0, round_decimals) > round(self.y1, round_decimals):
             exception_or_log_error(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1133,6 +1133,7 @@ class TestOfflineDataSetup(unittest.TestCase):
         _ = Page(id_=1, number=1, original_size=(595.2, 300.0), document=document, start_offset=0, end_offset=1)
         self.assertTrue(span.bbox())
 
+    @pytest.mark.xfail(reason='We now only log a warning because Azure OCR sometimes returns bboxes without height.')
     def test_get_span_bbox_with_characters_without_height_strict_validation(self):
         """
         Test get the bbox of a Span where the characters do not have height (OCR problem).
@@ -1176,6 +1177,7 @@ class TestOfflineDataSetup(unittest.TestCase):
         _ = Page(id_=1, number=1, original_size=(595.2, 300.0), document=document, start_offset=0, end_offset=1)
         self.assertTrue(span.bbox())
 
+    @pytest.mark.xfail(reason='We now only log a warning because Azure OCR sometimes returns bboxes without width.')
     def test_get_span_bbox_with_characters_without_width_strict_validation(self):
         """
         Test get the bbox of a Span where the characters do not have width (OCR problem).
@@ -1292,6 +1294,7 @@ class TestOfflineDataSetup(unittest.TestCase):
         _ = Page(id_=1, number=1, original_size=(595.2, 841.68), document=document, start_offset=0, end_offset=1)
         self.assertTrue(document.bboxes)
 
+    @pytest.mark.xfail(reason='We now only log a warning because Azure OCR sometimes returns bboxes without height.')
     def test_document_check_bbox_zero_height_allowed(self):
         """Test bbox check with zero height without strict validation."""
         document_bbox = {
@@ -1301,6 +1304,7 @@ class TestOfflineDataSetup(unittest.TestCase):
         _ = Page(id_=1, number=1, original_size=(595.2, 841.68), document=document, start_offset=0, end_offset=1)
         self.assertTrue(document.bboxes)
 
+    @pytest.mark.xfail(reason='We now only log a warning because Azure OCR sometimes returns bboxes without height.')
     def test_document_check_bbox_zero_height_strict_validation(self):
         """Test bbox check with zero height with strict validation, which does not allow it."""
         document_bbox = {
@@ -1326,6 +1330,7 @@ class TestOfflineDataSetup(unittest.TestCase):
         _ = Page(id_=1, number=1, original_size=(595.2, 841.68), document=document, start_offset=0, end_offset=1)
         self.assertTrue(document.bboxes)
 
+    @pytest.mark.xfail(reason='We now only log a warning because Azure OCR sometimes returns bboxes without width.')
     def test_document_check_bbox_zero_width_strict_validation(self):
         """Test bbox check with zero width with strict validation, which does not allow it."""
         document_bbox = {


### PR DESCRIPTION
This changes the behavior of the Bbox validation to only log a warning when encountering a zero width or height Bbox.