### PR TITLE
Fixed: Optimize spans/annotations data structures

### DIFF
--- a/konfuzio_sdk/tokenizer/regex.py
+++ b/konfuzio_sdk/tokenizer/regex.py
@@ -42,17 +42,17 @@ class RegexTokenizer(AbstractTokenizer):
         before_none = len(document.annotations(use_correct=False, label=document.project.no_label))
 
         t0 = time.monotonic()
-        spans = []
+        spans = {}
         # do not keep the full regex match as we will see many matches whitespaces as pre or suffix
         for span_info in regex_matches(document.text, self.regex, keep_full_match=False):
             span = Span(start_offset=span_info['start_offset'], end_offset=span_info['end_offset'])
             span.regex_matching.append(self)
-            if span not in spans:  # do not use duplicated spans  # todo add test
-                spans.append(span)
+            if (span_info['start_offset'], span_info['end_offset']) not in spans:  # do not use duplicated spans  # todo add test
+                spans[(span_info['start_offset'], span_info['end_offset'])] = span
 
         # Create a revised = False and is_correct = False (defaults) Annotation
         document_spans = {(span.start_offset, span.end_offset): span for span in document.spans()}
-        for span in spans:
+        for span in spans.values():
             span_key = (span.start_offset, span.end_offset)
             if span_key not in document_spans:  # (use_correct=False):
                 document_spans[span_key] = span

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -102,10 +102,10 @@ class TestOnlineProject(unittest.TestCase):
         # we are no longer filtering out the rejected Annotations so it's 21
         self.assertEqual(21, len(doc.annotations(use_correct=False)))
         # a multiline Annotation in the top right corner, see https://app.konfuzio.com/a/4419937
-        self.assertEqual(66, doc.annotations()[0]._spans[0].start_offset)
-        self.assertEqual(78, doc.annotations()[0]._spans[0].end_offset)
-        self.assertEqual(159, doc.annotations()[0]._spans[1].start_offset)
-        self.assertEqual(169, doc.annotations()[0]._spans[1].end_offset)
+        self.assertEqual(66, doc.annotations()[0].spans[0].start_offset)
+        self.assertEqual(78, doc.annotations()[0].spans[0].end_offset)
+        self.assertEqual(159, doc.annotations()[0].spans[1].start_offset)
+        self.assertEqual(169, doc.annotations()[0].spans[1].end_offset)
         self.assertEqual(len(doc.annotations()), 19)
         # helm: 21.06.2022 changed from 21 to 19 as someone added (?) two annotations?
         # todo check this number, the offline project was still working fine for all evaluation tests
@@ -663,7 +663,7 @@ class TestEqualityAnnotation(unittest.TestCase):
         cls.category = Category(project=cls.project, id_=1)
         cls.label_set = LabelSet(project=cls.project, categories=[cls.category], id_=421)
         cls.label_one = Label(project=cls.project, text='First', label_sets=[cls.label_set])
-        cls.label_two = Label(project=cls.project, text='First', label_sets=[cls.label_set])
+        cls.label_two = Label(project=cls.project, text='Second', label_sets=[cls.label_set])
         cls.document = Document(project=cls.project, category=cls.category)
         # cls.label_set.add_label(cls.label)
         cls.annotation_set = AnnotationSet(document=cls.document, label_set=cls.label_set)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -62,7 +62,8 @@ class TestCompare(unittest.TestCase):
         doc_a = prj.get_document_by_id(TEST_DOCUMENT_ID)
         doc_b = prj.get_document_by_id(TEST_DOCUMENT_ID)  # predicted
         doc_b.annotations()
-        doc_b._annotations.pop(0)  # pop an Annotation that is correct in BOTH  Documents
+        k = next(iter(doc_b._annotations))
+        doc_b._annotations.pop(k)  # pop an Annotation that is correct in BOTH  Documents
         assert doc_a._annotations == doc_b._annotations  # first Annotation is removed in both  Documents
         evaluation = compare(doc_a, doc_b)
         assert len(evaluation) == 22  # 21 if not considering negative Annotations, 2 Annotations are is_correct false
@@ -78,7 +79,7 @@ class TestCompare(unittest.TestCase):
         doc_a = prj.get_document_by_id(TEST_DOCUMENT_ID)
         doc_b = prj.get_document_by_id(TEST_DOCUMENT_ID)  # predicted
         doc_b.annotations()
-        doc_b._annotations.pop(11)  # pop an Annotation that is correct in BOTH  Documents
+        doc_b._annotations.popitem()  # pop an Annotation that is correct in BOTH  Documents
         assert doc_a._annotations == doc_b._annotations  # last Annotation is removed in both  Documents
         evaluation = compare(doc_a, doc_b)
         assert len(evaluation) == 23  # 22 if not considering negative Annotations, 2 Annotations are is_correct false

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -482,7 +482,7 @@ class TestRegexGenerator(unittest.TestCase):
                 findings = re.findall(auto_regex, document.text)
                 clean_findings = set([item for sublist in findings for item in sublist])
                 for anno in annos:
-                    for span in anno._spans:
+                    for span in anno.spans:
                         assert span.offset_string in clean_findings
 
     def test_annotation_to_regex(self):


### PR DESCRIPTION
* Change data structure for spans and annotations from list to dict
* Replace naive `in` checks with `dict.get`
* Ensure external interface (non-private functions) stay consistent
* Fix tests that checked private properties directly