### PR TITLE
Fixed: Trailing slashes at the end of the URLs passed at konfuzio_sdk init

### DIFF
--- a/konfuzio_sdk/cli.py
+++ b/konfuzio_sdk/cli.py
@@ -23,7 +23,8 @@ konfuzio_sdk create_Project >NAME<
 konfuzio_sdk export_project >ID<
     Download the data from a Project by ID to migrate it to another Host.
 konfuzio_sdk export_project >ID< include_ai
-    Download the data of a Project by ID to migrate it to another Host, including the (status) Done & Activated AI models
+    Download the data of a Project by ID to migrate it to another Host, including the (status) Done & Activated AI
+    models
 
 These commands should be run inside of your working directory.
 
@@ -36,9 +37,8 @@ def credentials():
     user = input("Username you use to login to Konfuzio Server: ")
     password = getpass("Password you use to login to Konfuzio Server: ")
     host = str(
-        input("Server Host URL (press [ENTER] for https://app.konfuzio.com): ")
-        or "https://app.konfuzio.com"
-    )
+        input("Server Host URL (press [ENTER] for https://app.konfuzio.com): ") or "https://app.konfuzio.com"
+    ).rstrip('/')
     return user, password, host
 
 
@@ -48,11 +48,7 @@ def main():
     if len(sys.argv) == 1 and sys.argv[0] == "init":
         user, password, host = credentials()
         init_env(user=user, password=password, host=host)
-    elif (
-        len(sys.argv) in range(2, 4)
-        and sys.argv[0] == "export_project"
-        and sys.argv[1].isdigit()
-    ):
+    elif len(sys.argv) in range(2, 4) and sys.argv[0] == "export_project" and sys.argv[1].isdigit():
         include_ais = False
         if len(sys.argv) == 3:
             include_ais = True if sys.argv[2] == "include_ai" else False

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -371,8 +371,8 @@ class Page(Data):
         """
         Retrieve the Category Annotation associated with a specific Category within this Page.
 
-        If no Category Annotation is found for the provided Category, one can be created based on the `add_if_not_present`
-        argument.
+        If no Category Annotation is found for the provided Category, one can be created based on the
+        `add_if_not_present` argument.
 
         :param category: The Category for which to retrieve the Category Annotation.
         :type category: Category
@@ -560,7 +560,8 @@ class Bbox:
         if round(self.y1, round_decimals) > round(self.page.height, round_decimals):
             exception_or_log_error(
                 msg=f"{self} exceeds height of {self.page} by "
-                f"{round(self.y1, round_decimals) - round(self.page.height, round_decimals)} with validation {validation}.",
+                f"{round(self.y1, round_decimals) - round(self.page.height, round_decimals)} "
+                f"with validation {validation}.",
                 fail_loudly=str(validation) != str(BboxValidationTypes.DISABLED),
                 exception_type=ValueError,
                 handler=handler,
@@ -569,7 +570,8 @@ class Bbox:
         if round(self.x1, round_decimals) > round(self.page.width, round_decimals):
             exception_or_log_error(
                 msg=f"{self} exceeds width of {self.page} by "
-                f"{round(self.x1, round_decimals) - round(self.page.width, round_decimals)} with validation {validation}.",
+                f"{round(self.x1, round_decimals) - round(self.page.width, round_decimals)} "
+                f"with validation {validation}.",
                 fail_loudly=str(validation) != str(BboxValidationTypes.DISABLED),
                 exception_type=ValueError,
                 handler=handler,
@@ -1481,14 +1483,14 @@ class Label(Data):
         """
         Get a list of Annotations that are identified by the least precise regular expressions.
 
-        This method iterates over the list of Categories and Annotations within each Category, collecting all the regexes
-        associated with them. It then evaluates these regexes and collects the top worst ones (i.e., those with the least
-        True Positives). For each of these top worst regexes, it returns the Annotations found by them but not by the best
-        regex for that label, potentially identifying them as outliers.
+        This method iterates over the list of Categories and Annotations within each Category, collecting all the
+        regexes associated with them. It then evaluates these regexes and collects the top worst ones (i.e., those with
+        the least True Positives). For each of these top worst regexes, it returns the Annotations found by them but
+        not by the best regex for that label, potentially identifying them as outliers.
 
-        To detect outlier Annotations with multi-Spans, the method iterates over all the multi-Span Annotations under the
-        Label and checks each Span that was not detected by the aforementioned worst regexes. If it is not found by any
-        other regex in the Project, the entire Annotation is considered a potential outlier.
+        To detect outlier Annotations with multi-Spans, the method iterates over all the multi-Span Annotations under
+        the Label and checks each Span that was not detected by the aforementioned worst regexes. If it is not found by
+        any other regex in the Project, the entire Annotation is considered a potential outlier.
 
         :param categories: A list of Category objects under which the search is conducted.
         :type categories: List[Category]
@@ -2068,7 +2070,7 @@ class AnnotationsContainer(dict):
     """
 
     def remove(self, obj):
-        """Delete an Annotation from the container. Mimicks the list.remove() method."""
+        """Delete an Annotation from the container. Mimicks the similar method of the list."""
         # obj._spans might be a list as it might come from a previous SDK version
         if isinstance(obj._spans, list):
             key = (
@@ -2080,7 +2082,7 @@ class AnnotationsContainer(dict):
         del self[key]
 
     def append(self, obj):
-        """Add an Annotation to the container. Mimicks the list.append() method."""
+        """Add an Annotation to the container. Mimicks the similar method of the list."""
         # obj._spans might be a list as it might come from a previous SDK version
         if isinstance(obj._spans, list):
             key = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,12 @@ class TestCLI(TestCase):
         """Test to init with default Host."""
         assert credentials() == ("myuser", "pw", "https://app.konfuzio.com")
 
+    @patch('builtins.input', side_effect=['myuser', 'https://konfuzio.yourcompany.com//'])
+    @patch("konfuzio_sdk.cli.getpass", side_effect=['pw'])
+    def test_removing_trailing_slashes(self, input, getpass):
+        """Test to ensure that any trailing slash(es) in the end of the host URL are removed."""
+        assert credentials() == ("myuser", "pw", "https://konfuzio.yourcompany.com")
+
     @patch('builtins.input', side_effect=['myuser', ''])
     @patch("konfuzio_sdk.cli.getpass", side_effect=['pw'])
     def test_init_project(self, input, getpass):


### PR DESCRIPTION
Now there is no error when a user passes a URL with a trailing slash in the end (e.g. https://app.konfuzio.com/).