### PR TITLE
"Use session host in konfuzio_sdk if available

### DIFF
--- a/konfuzio_sdk/api.py
+++ b/konfuzio_sdk/api.py
@@ -750,7 +750,9 @@ def get_all_project_ais(project_id: int, session=None, host: str = None) -> dict
     if session is None:
         session = konfuzio_session()
 
-    if host is None:
+    if hasattr(session, 'host'):
+        host = session.host
+    else:
         host = KONFUZIO_HOST
 
     urls = {


### PR DESCRIPTION
Modified the handling of 'host' variable in konfuzio_sdk/api.py to prioritize session host if it is set. This is to adapt to cases where the host differs from the KONFUZIO_HOST global variable."