### PR TITLE
Fixed: links in the documentation, image size in tokenizer output visualization

### DIFF
--- a/docs/sdk/sourcecode.rst
+++ b/docs/sdk/sourcecode.rst
@@ -172,11 +172,6 @@ Random Forest Extraction AI
    :members:
    :noindex:
 
-Load Saved AI Model
----------------------
-
-.. autofunction:: konfuzio_sdk.trainer.information_extraction.load_model
-   :noindex:
 
 Categorization AI
 =====================

--- a/docs/sdk/tutorials/build-context-aware-file-splitting-model/index_nb.md
+++ b/docs/sdk/tutorials/build-context-aware-file-splitting-model/index_nb.md
@@ -252,6 +252,6 @@ class ContextAwareFileSplittingModel(AbstractFileSplittingModel):
 
 ### What's next?
 
-- [Learn how to train and use Context-Aware File Splitting Model](https://dev.konfuzio.com/sdk/tutorials/tutorials/build-context-aware-file-splitting-model/index.html)
-- [Get to know how to build a custom File Splitting AI](https://dev.konfuzio.com/sdk/tutorials/tutorials/file-splitting-evaluation/index.html)
+- [Learn how to train and use Context-Aware File Splitting Model](https://dev.konfuzio.com/sdk/tutorials/build-context-aware-file-splitting-model/index.html)
+- [Get to know how to build a custom File Splitting AI](https://dev.konfuzio.com/sdk/tutorials/file-splitting-evaluation/index.html)
 

--- a/docs/sdk/tutorials/context-aware-file-splitting-model/index_nb.md
+++ b/docs/sdk/tutorials/context-aware-file-splitting-model/index_nb.md
@@ -163,5 +163,5 @@ os.remove(save_path)
 
 ### What's next?
 
-- [Learn how to create a custom File Splitting AI](https://dev.konfuzio.com/sdk/tutorials/tutorials/create-custom-splitting-ai/index.html)
-- [Find out how to evaluate a File Splitting AI's performance](https://dev.konfuzio.com/sdk/tutorials/tutorials/file-splitting-evaluation/index.html)
+- [Learn how to create a custom File Splitting AI](https://dev.konfuzio.com/sdk/tutorials/create-custom-splitting-ai/index.html)
+- [Find out how to evaluate a File Splitting AI's performance](https://dev.konfuzio.com/sdk/tutorials/file-splitting-evaluation/index.html)

--- a/docs/sdk/tutorials/outlier-annotations/index_nb.md
+++ b/docs/sdk/tutorials/outlier-annotations/index_nb.md
@@ -107,7 +107,7 @@ GROUND_TRUTH_DOCUMENTS = pipeline.documents
 PREDICTED_DOCUMENTS = predictions
 ```
 
-```python editable=true slideshow={"slide_type": ""}
+```python editable=true slideshow={"slide_type": ""} tags=["remove-output"]
 from konfuzio_sdk.evaluate import ExtractionEvaluation
 
 evaluation = ExtractionEvaluation(documents=list(zip(GROUND_TRUTH_DOCUMENTS, PREDICTED_DOCUMENTS)), strict=False)

--- a/docs/sdk/tutorials/tokenizers/index_nb.md
+++ b/docs/sdk/tutorials/tokenizers/index_nb.md
@@ -264,8 +264,8 @@ tokenized_doc = tokenizer(deepcopied_doc)
 ```
 
 ```python tags=["remove-cell"]
-tokenized_doc.pages()[0].image_width = 1414
-tokenized_doc.pages()[0].image_height = 2000
+tokenized_doc.pages()[0].image_width = 1100
+tokenized_doc.pages()[0].image_height = 1400
 ```
 
 ```python
@@ -388,4 +388,4 @@ We have seen the `WhitespaceTokenizer`, splitting text into chunks delimeted by 
 
 ### What's Next?
 
-<a href="/sdk/tutorials/information_extraction"> Find out how to train a custom Extraction AI model</a>.
+- <a href="/sdk/tutorials/information_extraction"> Find out how to train a custom Extraction AI model</a>


### PR DESCRIPTION
Fixed nonfunctional links in tutorials' footers, modified obsolete API references, changed image size for wrongly rendered output with Bboxes.