### PR TITLE
Added: functionality to tune hyperparameters for Label Set classifier independently

### DIFF
--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1415,7 +1415,13 @@ class GroupAnnotationSets:
         if not res_dict:
             logger.warning('res_dict is empty')
             return res_dict
-        n_nearest = self.label_set_n_nearest_template
+        n_nearest = (
+            self.label_set_n_nearest_template
+            if hasattr(self, 'label_set_n_nearest_template')
+            else self.n_nearest_template
+            if hasattr(self, 'n_nearest_template')
+            else 5
+        )
         feature_df = self.build_document_template_feature_X(text, self.dict_to_dataframe(res_dict)).filter(
             self.template_feature_list, axis=1
         )

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1418,9 +1418,7 @@ class GroupAnnotationSets:
         n_nearest = (
             self.label_set_n_nearest_template
             if hasattr(self, 'label_set_n_nearest_template')
-            else self.n_nearest_template
-            if hasattr(self, 'n_nearest_template')
-            else 5
+            else (self.n_nearest_template if hasattr(self, 'n_nearest_template') else 0)
         )
         feature_df = self.build_document_template_feature_X(text, self.dict_to_dataframe(res_dict)).filter(
             self.template_feature_list, axis=1
@@ -1584,7 +1582,7 @@ class RFExtractionAI(AbstractExtractionAI, GroupAnnotationSets):
         self.n_nearest_across_lines = n_nearest_across_lines
 
         # label set clf hyperparameters
-        self.label_set_n_nearest_template = kwargs.get('label_set_n_nearest_template', 1)
+        self.label_set_n_nearest_template = kwargs.get('label_set_n_nearest_template', 5)
         self.label_set_max_depth = kwargs.get('label_set_max_depth', 100)
         self.label_set_n_estimators = kwargs.get('label_set_n_estimators', 100)
         logger.info(f'label_set_n_nearest_template={self.label_set_n_nearest_template}')

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1582,6 +1582,9 @@ class RFExtractionAI(AbstractExtractionAI, GroupAnnotationSets):
         self.label_set_n_nearest_template = kwargs.get('label_set_n_nearest_template', 5)
         self.label_set_max_depth = kwargs.get('label_set_max_depth', 100)
         self.label_set_n_estimators = kwargs.get('label_set_n_estimators', 100)
+        logger.info(f'{self.label_set_n_nearest_template=}')
+        logger.info(f'{self.label_set_max_depth=}')
+        logger.info(f'{self.label_set_n_estimators=}')
 
         self.tokenizer = tokenizer
         logger.info(f'{tokenizer=}')

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1158,9 +1158,9 @@ class GroupAnnotationSets:
 
     def __init__(self):
         """Initialize TemplateClf."""
-        self.n_nearest_template = 5
-        self.max_depth = 100
-        self.n_estimators = 100
+        self.label_set_n_nearest_template = 5
+        self.label_set_max_depth = 100
+        self.label_set_n_estimators = 100
         self.label_set_clf = None
 
     def fit_label_set_clf(self) -> Tuple[Optional[object], Optional[List['str']]]:
@@ -1197,7 +1197,7 @@ class GroupAnnotationSets:
         # todo check if no category labels should be ignored
         self.template_feature_list = list(self.clf.classes_)  # list of label classifier targets
         # logger.warning("template_feature_list:", self.template_feature_list)
-        n_nearest = self.n_nearest_template  # if hasattr(self, 'n_nearest_template') else 0
+        n_nearest = self.label_set_n_nearest_template  # if hasattr(self, 'n_nearest_template') else 0
 
         # Pretty long feature generation
         df_train_label = self.df_train
@@ -1240,7 +1240,7 @@ class GroupAnnotationSets:
             return None, None
 
         label_set_clf = RandomForestClassifier(
-            n_estimators=self.n_estimators, max_depth=self.max_depth, random_state=420
+            n_estimators=self.label_set_n_estimators, max_depth=self.label_set_max_depth, random_state=420
         )
         label_set_clf.fit(x_train, y_train)
 
@@ -1570,13 +1570,18 @@ class RFExtractionAI(AbstractExtractionAI, GroupAnnotationSets):
         logger.info(f'{no_label_limit=}')
         logger.info(f'{n_nearest_across_lines=}')
 
-        self.use_separate_labels = use_separate_labels
         self.n_nearest = n_nearest
-        self.first_word = first_word
         self.max_depth = max_depth
         self.n_estimators = n_estimators
+        self.use_separate_labels = use_separate_labels
         self.no_label_limit = no_label_limit
+        self.first_word = first_word
         self.n_nearest_across_lines = n_nearest_across_lines
+
+        # label set clf hyperparameters
+        self.label_set_n_nearest_template = kwargs.get('label_set_n_nearest_template', 5)
+        self.label_set_max_depth = kwargs.get('label_set_max_depth', 100)
+        self.label_set_n_estimators = kwargs.get('label_set_n_estimators', 100)
 
         self.tokenizer = tokenizer
         logger.info(f'{tokenizer=}')

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1158,9 +1158,9 @@ class GroupAnnotationSets:
 
     def __init__(self):
         """Initialize TemplateClf."""
-        self.label_set_n_nearest_template = 5
         self.label_set_max_depth = 100
         self.label_set_n_estimators = 100
+        self.label_set_n_nearest_template = 5
         self.label_set_clf = None
 
     def fit_label_set_clf(self) -> Tuple[Optional[object], Optional[List['str']]]:
@@ -1197,8 +1197,7 @@ class GroupAnnotationSets:
         # todo check if no category labels should be ignored
         self.template_feature_list = list(self.clf.classes_)  # list of label classifier targets
         # logger.warning("template_feature_list:", self.template_feature_list)
-        n_nearest = self.label_set_n_nearest_template  # if hasattr(self, 'n_nearest_template') else 0
-
+        n_nearest = self.label_set_n_nearest_template
         # Pretty long feature generation
         df_train_label = self.df_train
 
@@ -1416,7 +1415,7 @@ class GroupAnnotationSets:
         if not res_dict:
             logger.warning('res_dict is empty')
             return res_dict
-        n_nearest = self.n_nearest_template if hasattr(self, 'n_nearest_template') else 0
+        n_nearest = self.label_set_n_nearest_template
         feature_df = self.build_document_template_feature_X(text, self.dict_to_dataframe(res_dict)).filter(
             self.template_feature_list, axis=1
         )
@@ -1579,12 +1578,12 @@ class RFExtractionAI(AbstractExtractionAI, GroupAnnotationSets):
         self.n_nearest_across_lines = n_nearest_across_lines
 
         # label set clf hyperparameters
-        self.label_set_n_nearest_template = kwargs.get('label_set_n_nearest_template', 5)
+        self.label_set_n_nearest_template = kwargs.get('label_set_n_nearest_template', 1)
         self.label_set_max_depth = kwargs.get('label_set_max_depth', 100)
         self.label_set_n_estimators = kwargs.get('label_set_n_estimators', 100)
-        logger.info(f'{self.label_set_n_nearest_template=}')
-        logger.info(f'{self.label_set_max_depth=}')
-        logger.info(f'{self.label_set_n_estimators=}')
+        logger.info(f'label_set_n_nearest_template={self.label_set_n_nearest_template}')
+        logger.info(f'label_set_max_depth={self.label_set_max_depth}')
+        logger.info(f'label_set_n_estimators={self.label_set_n_estimators}')
 
         self.tokenizer = tokenizer
         logger.info(f'{tokenizer=}')


### PR DESCRIPTION
* [x] Label Set Classifier now have independent hyperparameters that can be passed as keyword arguments when instantiating the `RFExtractionAI()` by the server (which can make them parameterizable from the UI)
* [x] Label Set Classifier hyperparameters are logged just like the rest of `RFExtractionAI()` parameters