### PR TITLE
Fixed: removing documents by indices instead of meaningful properties

### DIFF
--- a/docs/sdk/tutorials/data-preparation/index_nb.md
+++ b/docs/sdk/tutorials/data-preparation/index_nb.md
@@ -81,13 +81,14 @@ Then, create a new Document from each PDF in the list of paths `file_paths`:
 
 ```python
 for document_path in file_paths:
-    _ = Document.from_file(document_path, project=project, sync=False)
+    _ = Document.from_file(document_path, project=project, sync=True)
     print(f'Document {_.id_} successfully created.')
 ```
 ```python tags=["remove-cell"]
 project = Project(id_=TEST_PROJECT_ID, update=True)
-for document in project._documents[-len(file_paths):]:
-    document.delete(delete_online=True)
+for document in project._documents:
+    if document.name == 'pdf.pdf':
+        document.delete(delete_online=True)
 ```
 The `Document.from_file` method uploads a new Document to the Konfuzio server. The [documentation](https://dev.konfuzio.com/sdk/sourcecode.html#document) provides an overview of the returned values and optional paramenters for this method.
 

--- a/docs/sdk/tutorials/example-usage/index_nb.md
+++ b/docs/sdk/tutorials/example-usage/index_nb.md
@@ -359,11 +359,6 @@ ASSIGNEE_ID = None
 ```python tags=["skip-execution", "nbval-skip"]
 document = Document.from_file(FILE_PATH, project=my_project, sync=True)
 ```
-```python tags=['remove-cell']
-document = my_project._documents[-1]
-document.dataset_status = 0
-document.delete(delete_online=True)
-```
 
 2. **Asynchronous upload (sync=False)**: With this setting, the method immediately returns an empty Document object 
 after initiating the upload. The OCR processing takes place in the background. This method is advantageous when 

--- a/docs/sdk/tutorials/tokenizers/index_nb.md
+++ b/docs/sdk/tutorials/tokenizers/index_nb.md
@@ -280,7 +280,10 @@ tokenized_doc.get_page_by_index(0).get_annotations_image(display_all=True)
 ```
 
 ```python tags=["remove-cell"]
-sample_doc.delete(delete_online=True)
+my_project = Project(id_=TEST_PROJECT_ID, update=True)
+for document in my_project._documents:
+    if document.name == 'sample.pdf':
+        document.delete(delete_online=True)
 ```
 
 Note that this example uses a PDF file named 'sample.pdf', you can download this file <a href="sample.pdf">here</a> in case you wish to try running this code.


### PR DESCRIPTION
- documents used in test pipelines are removed using meaningful properties instead of accessing them by indices 