### PR TITLE
Changed: Bento optimizations

### DIFF
--- a/konfuzio_sdk/bento/extraction/rfextractionai_service.py
+++ b/konfuzio_sdk/bento/extraction/rfextractionai_service.py
@@ -52,9 +52,8 @@ class ExtractionService:
         # Run the extraction in a separate thread, otherwise the API server will block
         result = await asyncio.get_event_loop().run_in_executor(self.executor, self.extraction_model.extract, document)
         annotations_result = process_response(result)
-        # Remove the Document and its deepcopy from the Project to avoid memory leaks
-        project._documents.remove(document)
-        project._documents.remove(result)
+        # Remove the Document and its copies from the Project to avoid memory leaks
+        project._documents = [d for d in project._documents if d.id_ != document.id_ and d.copy_of_id != document.id_]
         return annotations_result
 
 

--- a/konfuzio_sdk/bento/extraction/rfextractionai_service.py
+++ b/konfuzio_sdk/bento/extraction/rfextractionai_service.py
@@ -52,6 +52,9 @@ class ExtractionService:
         # Run the extraction in a separate thread, otherwise the API server will block
         result = await asyncio.get_event_loop().run_in_executor(self.executor, self.extraction_model.extract, document)
         annotations_result = process_response(result)
+        # Remove the Document and its deepcopy from the Project to avoid memory leaks
+        project._documents.remove(document)
+        project._documents.remove(result)
         return annotations_result
 
 

--- a/konfuzio_sdk/bento/extraction/utils.py
+++ b/konfuzio_sdk/bento/extraction/utils.py
@@ -63,6 +63,9 @@ def prepare_request(request: BaseModel, project: Project, konfuzio_sdk_version: 
     """
     # Extraction AIs include only one Category per Project.
     category = project.categories[0]
+    # Calculate next available ID based on current Project documents to avoid conflicts.
+    document_id = max((doc.id_ for doc in project._documents if doc.id_), default=0) + 1
+
     if request.__class__.__name__ == 'ExtractRequest20240117':
         bboxes = {}
         for bbox_id, bbox in request.bboxes.items():
@@ -81,6 +84,7 @@ def prepare_request(request: BaseModel, project: Project, konfuzio_sdk_version: 
                 bboxes[str(bbox_id)]['top'] = round(page.original_size[1] - bbox.y0, 4)
                 bboxes[str(bbox_id)]['bottom'] = round(page.original_size[1] - bbox.y1, 4)
         document = Document(
+            id_=document_id,
             text=request.text,
             bbox=bboxes,
             project=project,

--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -852,11 +852,8 @@ class AbstractExtractionAI(BaseModel):
                     'AI_MODEL_NAME',
                 ],
                 labels=self.bento_metadata,
-                # TODO replace with latest version after release
                 python={
-                    'packages': [
-                        'https://github.com/konfuzio-ai/konfuzio-sdk/archive/refs/heads/master.zip#egg=konfuzio-sdk'
-                    ],
+                    'packages': [f'konfuzio-sdk=={self.konfuzio_sdk_version}'],
                     'lock_packages': True,
                 },
                 build_ctx=temp_dir,


### PR DESCRIPTION
- [x] Async running of `extract` to avoid blocking health check endpoints (see [docs](https://docs.bentoml.com/en/latest/guides/services.html#synchronous-and-asynchronous-apis))
- [x] Use `self.konfuzio_sdk_version` when building bento
- [x] Set an ID on documents before processing them so they can be selectively removed (together with their deepcopies) once extraction is done, to avoid memory leaks