### PR TITLE
Revert "Fixed: inconsistent evaluation of Spans containing more than one word"

### DIFF
--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -2295,7 +2295,7 @@ class Annotation(Data):
                 self.label in self.annotation_set.label_set.labels
             ), f'{self.label} is not in {self.annotation_set.label_set.labels} of {self.annotation_set}.'
 
-        for i, span in enumerate(spans) or enumerate([]):
+        for i, span in enumerate(spans or []):
             if (i != len(spans) - 1) and (self.document.text is not None):
                 current_span = spans[i]
                 next_span = spans[i + 1]

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -2296,7 +2296,7 @@ class Annotation(Data):
             ), f'{self.label} is not in {self.annotation_set.label_set.labels} of {self.annotation_set}.'
 
         for i, span in enumerate(spans) or enumerate([]):
-            if i != len(spans) - 1:
+            if (i != len(spans) - 1) and (self.document.text is not None):
                 current_span = spans[i]
                 next_span = spans[i + 1]
                 current_span_end_offset = current_span.end_offset

--- a/konfuzio_sdk/data.py
+++ b/konfuzio_sdk/data.py
@@ -48,6 +48,7 @@ from konfuzio_sdk.utils import (
     get_file_type_and_extension,
     get_merged_bboxes,
     get_missing_offsets,
+    is_composed_of_spaces_and_tabs,
     is_file,
     normalize_name,
     sdk_isinstance,
@@ -2294,7 +2295,17 @@ class Annotation(Data):
                 self.label in self.annotation_set.label_set.labels
             ), f'{self.label} is not in {self.annotation_set.label_set.labels} of {self.annotation_set}.'
 
-        for span in spans or []:
+        for i, span in enumerate(spans) or enumerate([]):
+            if i != len(spans) - 1:
+                current_span = spans[i]
+                next_span = spans[i + 1]
+                current_span_end_offset = current_span.end_offset
+                next_span_start_offset = next_span.start_offset
+                text_in_between = self.document.text[current_span_end_offset:next_span_start_offset]
+                if is_composed_of_spaces_and_tabs(text_in_between):
+                    logger.warning(
+                        f'Please merge Spans {current_span} and {next_span} that are horizontally next to each other and on the same line. Such unmerged Spans may lead to inaccurate Evaluation results.'
+                    )
             self.add_span(span)
 
         self.selection_bbox = kwargs.get('selection_bbox', None)

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -13,7 +13,6 @@ from konfuzio_sdk.data import Category, Document
 from konfuzio_sdk.utils import memory_size_of, sdk_isinstance
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 RELEVANT_FOR_EVALUATION = [
@@ -56,8 +55,6 @@ RELEVANT_FOR_EVALUATION = [
     'tmp_id_',  # a temporary ID used for enumerating the predicted annotations solely
     'disambiguated_id',  # an ID for multi-span annotations
 ]
-
-logger = logging.getLogger(__name__)
 
 
 def grouped(group, target: str):

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -15,7 +15,6 @@ from konfuzio_sdk.utils import memory_size_of, sdk_isinstance
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 warnings.simplefilter(action='ignore', category=FutureWarning)
-warnings.simplefilter(action='ignore', category=pd.errors.SettingWithCopyWarning)
 
 RELEVANT_FOR_EVALUATION = [
     'is_matched',  # needed to group spans in Annotations
@@ -140,7 +139,7 @@ def compare(
     :return: Evaluation DataFrame
     """
     df_a = pd.DataFrame(doc_a.eval_dict(use_correct=only_use_correct))
-    df_a_ids = df_a[['id_']]
+    df_a_ids = df_a[['id_']].copy()
     duplicated_ids = df_a_ids['id_'].duplicated(keep=False)
     df_a_ids['disambiguated_id'] = df_a_ids['id_'].astype(str)
     df_a_ids.loc[duplicated_ids, 'disambiguated_id'] += '_' + (df_a_ids.groupby('id_').cumcount() + 1).astype(str)

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -109,30 +109,6 @@ def prioritize_rows(group):
         return first_false_negative
 
 
-def split_row_based_on_offset_string(row: pd.Series) -> pd.DataFrame:
-    """
-    Split a row based on the offset string. If the offset_string has multiple words split by a whitespace,
-    then the row is split into multiple rows. The offset_string is split into multiple words and each word is
-    used as offset_string value in the new row. The other columns are copied from the original row.
-    """
-    words = row['offset_string'].split()
-    if len(words) > 1:
-        new_rows = []
-        start = row['start_offset']
-        end = row['end_offset']
-        for word in words:
-            new_row = row.copy()
-            end = start + len(word)
-            new_row['offset_string'] = word
-            new_row['start_offset'] = start
-            new_row['end_offset'] = end
-            start = end + 1
-            new_rows.append(new_row)
-        return pd.DataFrame(new_rows)
-    else:
-        return pd.DataFrame([row])
-
-
 def compare(
     doc_a,
     doc_b,
@@ -142,7 +118,6 @@ def compare(
     strict=True,
     id_counter: int = 1,
     custom_threshold=None,
-    split_spans_by_whitespace=False,
 ) -> pd.DataFrame:
     """Compare the Annotations of two potentially empty Documents wrt. to **all** Annotations.
 
@@ -161,8 +136,6 @@ def compare(
     :return: Evaluation DataFrame
     """
     df_a = pd.DataFrame(doc_a.eval_dict(use_correct=only_use_correct))
-    if split_spans_by_whitespace:
-        df_a = pd.concat(df_a.apply(split_row_based_on_offset_string, axis=1).tolist(), ignore_index=True)
     df_a_ids = df_a[['id_']]
     duplicated_ids = df_a_ids['id_'].duplicated(keep=False)
     df_a_ids['disambiguated_id'] = df_a_ids['id_'].astype(str)
@@ -175,8 +148,6 @@ def compare(
             ignore_below_threshold=ignore_below_threshold,
         ),
     )
-    if split_spans_by_whitespace:
-        df_b = pd.concat(df_b.apply(split_row_based_on_offset_string, axis=1).tolist(), ignore_index=True)
     df_b['tmp_id_'] = list(range(id_counter, id_counter + len(df_b)))
 
     if doc_a.category != doc_b.category:
@@ -473,7 +444,6 @@ class ExtractionEvaluation:
         strict: bool = True,
         use_view_annotations: bool = True,
         ignore_below_threshold: bool = True,
-        split_spans_by_whitespace: bool = False,
         zero_division='warn',
     ):
         """
@@ -497,7 +467,6 @@ class ExtractionEvaluation:
         logger.info(f'Initializing Evaluation object with {len(documents)} documents. Evaluation mode {strict=}.')
         self.documents = documents
         self.strict = strict
-        self.split_spans_by_whitespace = split_spans_by_whitespace
         self.use_view_annotations = use_view_annotations
         self.ignore_below_threshold = ignore_below_threshold
         self.only_use_correct = True
@@ -521,7 +490,6 @@ class ExtractionEvaluation:
                 use_view_annotations=self.use_view_annotations,
                 ignore_below_threshold=self.ignore_below_threshold,
                 id_counter=id_counter,
-                split_spans_by_whitespace=self.split_spans_by_whitespace,
             )
             evaluations.append(evaluation)
             id_counter += len(evaluation)

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -12,6 +12,7 @@ from konfuzio_sdk.data import Category, Document
 from konfuzio_sdk.utils import memory_size_of, sdk_isinstance
 
 logger = logging.getLogger(__name__)
+pandas_logger = logging.getLogger('pandas').setLevel(logging.ERROR)
 
 RELEVANT_FOR_EVALUATION = [
     'is_matched',  # needed to group spans in Annotations
@@ -381,7 +382,7 @@ class EvaluationCalculator:
                 raise ZeroDivisionError('TP and FP are zero, impossible to calculate precision.')
             elif self.zero_division == 'warn':
                 precision = 0
-                logging.warning('TP and FP are zero, precision is set to 0.')
+                logging.info('TP and FP are zero, precision is set to 0.')
             else:
                 precision = self.zero_division
         return precision
@@ -400,7 +401,7 @@ class EvaluationCalculator:
                 raise ZeroDivisionError('TP and FN are zero, recall is impossible to calculate.')
             elif self.zero_division == 'warn':
                 recall = 0
-                logging.warning('TP and FN are zero, recall is set to 0.')
+                logging.info('TP and FN are zero, recall is set to 0.')
             else:
                 recall = self.zero_division
         return recall
@@ -419,7 +420,7 @@ class EvaluationCalculator:
                 raise ZeroDivisionError('Precision and recall are zero, F1 is impossible to calculate.')
             elif self.zero_division == 'warn':
                 f1 = 0
-                logging.warning('Precision and recall are zero, F1 score is set to 0.')
+                logging.info('Precision and recall are zero, F1 score is set to 0.')
             else:
                 f1 = self.zero_division
         return f1

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -1,6 +1,7 @@
 """Calculate the accuracy on any level in a  Document."""
 
 import logging
+import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -13,7 +14,8 @@ from konfuzio_sdk.utils import memory_size_of, sdk_isinstance
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
-pandas_logger = logging.getLogger('pandas').setLevel(logging.ERROR)
+warnings.simplefilter(action='ignore', category=FutureWarning)
+warnings.simplefilter(action='ignore', category=pd.errors.SettingWithCopyWarning)
 
 RELEVANT_FOR_EVALUATION = [
     'is_matched',  # needed to group spans in Annotations

--- a/konfuzio_sdk/evaluate.py
+++ b/konfuzio_sdk/evaluate.py
@@ -12,6 +12,7 @@ from konfuzio_sdk.data import Category, Document
 from konfuzio_sdk.utils import memory_size_of, sdk_isinstance
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 pandas_logger = logging.getLogger('pandas').setLevel(logging.ERROR)
 
 RELEVANT_FOR_EVALUATION = [

--- a/konfuzio_sdk/settings_importer.py
+++ b/konfuzio_sdk/settings_importer.py
@@ -71,5 +71,5 @@ def get_handlers():
 
 
 logging.basicConfig(
-    level=config('LOGGING_LEVEL', default=logging.INFO, cast=int), format=LOG_FORMAT, handlers=get_handlers()
+    level=config('LOGGING_LEVEL', default=logging.WARNING, cast=int), format=LOG_FORMAT, handlers=get_handlers()
 )

--- a/konfuzio_sdk/utils.py
+++ b/konfuzio_sdk/utils.py
@@ -341,6 +341,11 @@ def slugify(value):
     return re.sub(r'[-\s\:\.]+', '-', value).replace('-_', '_')
 
 
+def is_composed_of_spaces_and_tabs(s: str) -> bool:
+    """Check if the string contains only spaces and tabs using a regex"""
+    return re.fullmatch(r'[ \t]*', s) is not None
+
+
 def normalize_name(value: str) -> str:
     """
     Normalize names for different Konfuzio concepts by removing slashes and checking for non-ascii symbols.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 log_cli=1
-log_cli_level=Info
 log_cli_format = %(asctime)s [%(levelname)8s] (%(filename)s:%(lineno)s) | %(message)s
 # addopts = --doctest-modules
 markers =

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setuptools.setup(
         'filetype==1.0.7',  # Used to check that files are in the correct format
         'lz4>=4.3.2',  # Used to compress pickles
         'matplotlib==3.7.1',
-        'nltk>=3.6.3',
+        'nltk>=3.6.3,<3.8.2',
         'numpy==1.23.5',
         'pandas>=1.3.5,<2.0.0',
         'Pillow>=8.4.0',

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -18,7 +18,7 @@ from konfuzio_sdk.evaluate import (
 )
 from konfuzio_sdk.samples import LocalTextProject
 from konfuzio_sdk.settings_importer import is_dependency_installed
-from konfuzio_sdk.tokenizer.regex import ConnectedTextTokenizer, WhitespaceTokenizer
+from konfuzio_sdk.tokenizer.regex import ConnectedTextTokenizer
 from konfuzio_sdk.trainer.file_splitting import ContextAwareFileSplittingModel, FileSplittingEvaluation, SplittingAI
 from tests.variables import OFFLINE_PROJECT, TEST_DOCUMENT_ID
 
@@ -1005,29 +1005,6 @@ class TestCompare(unittest.TestCase):
             target='target',
         )
         assert result['defined_to_be_correct_target'].to_list() == [1, 1]
-
-    def test_split_span_evaluation(self):
-        """Test strict mode of evaluation with and without split_spans_by_whitespace."""
-        project = Project(id_=14392)
-        tokenizer = WhitespaceTokenizer()
-        doc = project.get_document_by_id(5589024)
-        doc_2 = deepcopy(doc)
-        doc_2 = tokenizer.tokenize(doc_2)
-        _ = Annotation(
-            label_set=doc.annotations()[2].label_set,
-            spans=[Span(1336, 1343), Span(1344, 1348)],
-            document=doc_2,
-            label=doc.annotations()[2].label,
-            confidence=1,
-        )
-        _.annotation_set.id_ = 1
-        # doc annotation spans: [Span (1336, 1348): "July 6, 1960"]
-        # doc_2 annotation spans: [Span (1336, 1343): "July 6,", Span (1344, 1348): "1960"]
-        docs_to_evaluate = [(doc, doc_2)]
-        evaluation = ExtractionEvaluation(docs_to_evaluate, strict=True, split_spans_by_whitespace=True)
-        assert evaluation.f1(search=doc.annotations()[2].label) == 1.0
-        evaluation = ExtractionEvaluation(docs_to_evaluate, strict=True, split_spans_by_whitespace=False)
-        assert evaluation.f1(search=doc.annotations()[2].label) == 0.0
 
 
 @parameterized.parameterized_class(


### PR DESCRIPTION
For the moment, and from a strategic perspective, there was no legitimate reason to make a big change to the Extraction AI Evaluation, instead we could just log a warning about the inconsistent evaluation results for Custom Extraction AIs that are not applying the right post-processing to their predictions. 

* [x] Added WARNING message once trying to create an `Annotation` using two or more `Spans` that could be merged into one `Span` (for example separated by tabs or whitespaces)
* [x] Increased the logging level for the integrity of SDK to WARNING instead of INFO to avoid having very lengthy evaluation logs (currently above 2000 lines of logs for a sample evaluation cf. [12588](https://git.konfuzio.com/konfuzio/objectives/-/issues/12588))
* [x] Changed WARNING about 'TP and FP are zero, precision is set to 0.' to an INFO
* [x] Check that servers logging level is not affected
* [x] Check server tests pass successfully