### PR TITLE
Fixed: limit pkl_name to 63 characters

### DIFF
--- a/konfuzio_sdk/trainer/information_extraction.py
+++ b/konfuzio_sdk/trainer/information_extraction.py
@@ -1178,7 +1178,15 @@ class AbstractExtractionAI(BaseModel):
     @property
     def pkl_name(self) -> str:
         """Generate a name for the pickle file."""
-        return f'{self.name_lower()}_{self.category.id_ if self.category.id_ else 0}_{slugify(self.category.name)}_{get_timestamp()}'
+        # Bento tag names must be 63 characters or less.
+        # To ensure this and not lose relevant information, we first build separate parts of the name that do not
+        # include the category name, which is the only thing that can be reasonably truncated to fit.
+        prefix = f'{self.name_lower()}_{self.category.id_ if self.category.id_ else 0}_'
+        suffix = f'_{get_timestamp()}'
+        # The category name is the only part that can be truncated, so we truncate it to 63 - len(prefix) - len(suffix).
+        category_name = slugify(self.category.name)[: 63 - len(prefix) - len(suffix)]
+        # Put all the pieces back together to form the final, 63 character or less name.
+        return f'{prefix}{category_name}{suffix}'
 
     @property
     def temp_pkl_file_path(self) -> str:

--- a/tests/trainer/test_information_extraction.py
+++ b/tests/trainer/test_information_extraction.py
@@ -496,6 +496,14 @@ class TestWhitespaceRFExtractionAI(unittest.TestCase):
         assert len(res_doc.annotations(use_correct=False, ignore_below_threshold=True)) == 19
         return
 
+    def test_14_pkl_name(self):
+        """Test pkl_name not exceeding 63 characters."""
+        self.pipeline.category = self.project.get_category_by_id(id_=63)
+        self.pipeline.category.name = 'This is a very very very very very very very very very very long name'
+        assert len(self.pipeline.pkl_name) == 63
+        self.pipeline.category.name = 'short'
+        assert len(self.pipeline.pkl_name) < 63
+
     @classmethod
     def tearDownClass(cls) -> None:
         """Clear Project files."""


### PR DESCRIPTION
- [x] Bento tag names > 63 characters are not supported, so we limit the auto-generated `pkl_name` to take this into consideration.